### PR TITLE
Fetch remote `dylint_driver` in `dylint_testing` by default

### DIFF
--- a/examples/allow_clippy/Cargo.toml
+++ b/examples/allow_clippy/Cargo.toml
@@ -16,7 +16,7 @@ if_chain = "1.0.1"
 dylint_linting = { path = "../../utils/linting" }
 
 [dev-dependencies]
-dylint_testing = { path = "../../utils/testing" }
+dylint_testing = { path = "../../utils/testing", default-features = false }
 
 [workspace]
 members = ["."]

--- a/examples/clippy/Cargo.toml
+++ b/examples/clippy/Cargo.toml
@@ -26,7 +26,7 @@ tempfile = "3.2.0"
 test-env-log = "0.2.6"
 
 dylint = { path = "../../dylint" }
-dylint_testing = { path = "../../utils/testing" }
+dylint_testing = { path = "../../utils/testing", default-features = false }
 
 [workspace]
 members = ["."]

--- a/examples/env_literal/Cargo.toml
+++ b/examples/env_literal/Cargo.toml
@@ -16,7 +16,7 @@ if_chain = "1.0.1"
 dylint_linting = { path = "../../utils/linting" }
 
 [dev-dependencies]
-dylint_testing = { path = "../../utils/testing" }
+dylint_testing = { path = "../../utils/testing", default-features = false }
 
 [workspace]
 members = ["."]

--- a/examples/path_separator_in_string_literal/Cargo.toml
+++ b/examples/path_separator_in_string_literal/Cargo.toml
@@ -16,7 +16,7 @@ if_chain = "1.0.1"
 dylint_linting = { path = "../../utils/linting" }
 
 [dev-dependencies]
-dylint_testing = { path = "../../utils/testing" }
+dylint_testing = { path = "../../utils/testing", default-features = false }
 
 [workspace]
 members = ["."]

--- a/examples/question_mark_in_expression/Cargo.toml
+++ b/examples/question_mark_in_expression/Cargo.toml
@@ -16,7 +16,7 @@ if_chain = "1.0.1"
 dylint_linting = { path = "../../utils/linting" }
 
 [dev-dependencies]
-dylint_testing = { path = "../../utils/testing" }
+dylint_testing = { path = "../../utils/testing", default-features = false }
 
 [workspace]
 members = ["."]

--- a/utils/testing/Cargo.toml
+++ b/utils/testing/Cargo.toml
@@ -16,3 +16,7 @@ serde_json = "1.0.64"
 
 dylint = { version = "=0.1.0", path = "../../dylint" }
 dylint_internal = { version = "=0.1.0", path = "../../internal" }
+
+[features]
+default = ["dylint_driver_remote"]
+dylint_driver_remote = ["dylint/dylint_driver_remote"]


### PR DESCRIPTION
The driver builder uses a remote `dylint_driver` package if building in release mode or if `dylint_driver_remote` is enabled.

https://github.com/smoelius/dylint/blob/844a3ab339d0dcf69102044368b1bbd907b45787/dylint/src/driver_builder.rs#L112-L113

So when `dylint_testing` is built in debug mode, it looks for a local `dylint_driver` package and cannot find one.

A solution is to have `dylint_testing` enable the `dylint_driver_remote` feature by default.

I think I would prefer the feature be `dylint_driver_local`, but this solves the immediate problem.