### PR TITLE
`dylint_driver_remote` -> `dylint_driver_local`

### DIFF
--- a/cargo-dylint/Cargo.toml
+++ b/cargo-dylint/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/trailofbits/dylint"
 anyhow = "1.0.38"
 env_logger = "0.8.3"
 
-dylint = { version = "=0.1.1", path = "../dylint" }
+dylint = { version = "=0.1.1", path = "../dylint", features = ["dylint_driver_local"] }
 
 [dev-dependencies]
 assert_cmd = "1.0.3"

--- a/cargo-dylint/tests/list.rs
+++ b/cargo-dylint/tests/list.rs
@@ -7,7 +7,7 @@ use tempfile::tempdir;
 use test_env_log::test;
 
 const DYLINT_TEMPLATE_URL: &str = "https://github.com/trailofbits/dylint-template";
-const DYLINT_TEMPLATE_REV: &str = "43fec254e0e3cae1ba3e2e483585e333539ad192";
+const DYLINT_TEMPLATE_REV: &str = "fc9d0e025d2d9d57ea9cc9bb1764047bbc8ae609";
 
 const CHANNEL_A: &str = "nightly-2021-02-11";
 const CHANNEL_B: &str = "nightly-2021-04-08";

--- a/dylint/Cargo.toml
+++ b/dylint/Cargo.toml
@@ -28,4 +28,4 @@ dylint_examples = { version = "=0.1.1", path = "../examples" }
 
 [features]
 default = []
-dylint_driver_remote = []
+dylint_driver_local = []

--- a/dylint/src/driver_builder.rs
+++ b/dylint/src/driver_builder.rs
@@ -121,11 +121,11 @@ fn build(toolchain: &str, driver: &Path) -> Result<()> {
 
     let version_spec = format!("version = \"={}\"", env!("CARGO_PKG_VERSION"));
 
-    // smoelius: Fetch the `dylint_driver` package from crates.io if built in release mode or if
-    // `dylint_driver_remote` is enabled.
-    #[cfg(any(not(debug_assertions), feature = "dylint_driver_remote"))]
+    // smoelius: Assume the `dylint_driver` package is local if building in debug mode and if
+    // `dylint_driver_local` is enabled.
+    #[cfg(any(not(debug_assertions), not(feature = "dylint_driver_local")))]
     let path_spec = "";
-    #[cfg(all(debug_assertions, not(feature = "dylint_driver_remote")))]
+    #[cfg(all(debug_assertions, feature = "dylint_driver_local"))]
     let path_spec = format!(
         ", path = \"{}\"",
         Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/examples/allow_clippy/Cargo.toml
+++ b/examples/allow_clippy/Cargo.toml
@@ -16,7 +16,7 @@ if_chain = "1.0.1"
 dylint_linting = { path = "../../utils/linting" }
 
 [dev-dependencies]
-dylint_testing = { path = "../../utils/testing", default-features = false }
+dylint_testing = { path = "../../utils/testing", features = ["dylint_driver_local"] }
 
 [workspace]
 members = ["."]

--- a/examples/clippy/Cargo.toml
+++ b/examples/clippy/Cargo.toml
@@ -26,7 +26,7 @@ tempfile = "3.2.0"
 test-env-log = "0.2.6"
 
 dylint = { path = "../../dylint" }
-dylint_testing = { path = "../../utils/testing", default-features = false }
+dylint_testing = { path = "../../utils/testing", features = ["dylint_driver_local"] }
 
 [workspace]
 members = ["."]

--- a/examples/env_literal/Cargo.toml
+++ b/examples/env_literal/Cargo.toml
@@ -16,7 +16,7 @@ if_chain = "1.0.1"
 dylint_linting = { path = "../../utils/linting" }
 
 [dev-dependencies]
-dylint_testing = { path = "../../utils/testing", default-features = false }
+dylint_testing = { path = "../../utils/testing", features = ["dylint_driver_local"] }
 
 [workspace]
 members = ["."]

--- a/examples/path_separator_in_string_literal/Cargo.toml
+++ b/examples/path_separator_in_string_literal/Cargo.toml
@@ -16,7 +16,7 @@ if_chain = "1.0.1"
 dylint_linting = { path = "../../utils/linting" }
 
 [dev-dependencies]
-dylint_testing = { path = "../../utils/testing", default-features = false }
+dylint_testing = { path = "../../utils/testing", features = ["dylint_driver_local"] }
 
 [workspace]
 members = ["."]

--- a/examples/question_mark_in_expression/Cargo.toml
+++ b/examples/question_mark_in_expression/Cargo.toml
@@ -16,7 +16,7 @@ if_chain = "1.0.1"
 dylint_linting = { path = "../../utils/linting" }
 
 [dev-dependencies]
-dylint_testing = { path = "../../utils/testing", default-features = false }
+dylint_testing = { path = "../../utils/testing", features = ["dylint_driver_local"] }
 
 [workspace]
 members = ["."]

--- a/utils/testing/Cargo.toml
+++ b/utils/testing/Cargo.toml
@@ -18,5 +18,5 @@ dylint = { version = "=0.1.1", path = "../../dylint" }
 dylint_internal = { version = "=0.1.1", path = "../../internal" }
 
 [features]
-default = ["dylint_driver_remote"]
-dylint_driver_remote = ["dylint/dylint_driver_remote"]
+default = []
+dylint_driver_local = ["dylint/dylint_driver_local"]


### PR DESCRIPTION
This change is necessary because a crate graph only gets one copy of a dependency.