### PR TITLE
Add Toolchain Folder to Path, instead of copying dll's.

### DIFF
--- a/dylint/src/driver_builder.rs
+++ b/dylint/src/driver_builder.rs
@@ -100,13 +100,13 @@ fn dylint_drivers() -> Result<PathBuf> {
 }
 
 fn is_outdated(opts: &crate::Dylint, driver: &Path, toolchain: &str) -> Result<bool> {
-    let path = env::var(env::PATH)?;
+    let path = var(env::PATH)?;
 
     let path = {
         if cfg!(target_os = "windows") {
             // MinerSebas: To succesfully determine the dylint driver Version on Windows,
             // it is neccesary to add some Libraries to the Path.
-            let rustup_home = env::var(env::RUSTUP_HOME)?;
+            let rustup_home = var(env::RUSTUP_HOME)?;
 
             join_paths(
                 std::iter::once(

--- a/internal/src/env.rs
+++ b/internal/src/env.rs
@@ -10,6 +10,7 @@ pub const DYLINT_LIBRARY_PATH: &str = "DYLINT_LIBRARY_PATH";
 pub const DYLINT_LIBS: &str = "DYLINT_LIBS";
 pub const DYLINT_LIST: &str = "DYLINT_LIST";
 pub const DYLINT_RUSTFLAGS: &str = "DYLINT_RUSTFLAGS";
+pub const PATH: &str = "PATH";
 pub const RUSTC_WORKSPACE_WRAPPER: &str = "RUSTC_WORKSPACE_WRAPPER";
 pub const RUST_BACKTRACE: &str = "RUST_BACKTRACE";
 pub const RUSTFLAGS: &str = "RUSTFLAGS";


### PR DESCRIPTION
In #43 one of the fixes was to copy Libraries to the Driver Folder.
This PR instead provides those Libraries by adding them to the Path that's supplied when determining the Driver Version.

This doesn't have to be merged, its just an alternate Solution I wanted to bring up.