### PR TITLE
Have all workspaces share a target directory

### DIFF
--- a/cargo-dylint/tests/metadata.rs
+++ b/cargo-dylint/tests/metadata.rs
@@ -1,8 +1,9 @@
-use cargo_metadata::{Dependency, Metadata, MetadataCommand, Version};
+use cargo_metadata::{Dependency, Metadata, Version};
+use dylint_internal::cargo::current_metadata;
 use lazy_static::lazy_static;
 
 lazy_static! {
-    static ref METADATA: Metadata = MetadataCommand::new().no_deps().exec().unwrap();
+    static ref METADATA: Metadata = current_metadata().unwrap();
 }
 
 #[test]

--- a/cargo-dylint/tests/warn.rs
+++ b/cargo-dylint/tests/warn.rs
@@ -1,13 +1,30 @@
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
-use std::path::Path;
+use tempfile::tempdir;
 use test_env_log::test;
 
 #[test]
 fn no_libraries_were_found() {
+    let tempdir = tempdir().unwrap();
+
+    std::process::Command::new("cargo")
+        .current_dir(tempdir.path())
+        .args(&[
+            "init",
+            "--name",
+            tempdir
+                .path()
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .trim_start_matches('.'),
+        ])
+        .assert()
+        .success();
+
     std::process::Command::cargo_bin("cargo-dylint")
         .unwrap()
-        .current_dir(Path::new("..").join("driver"))
+        .current_dir(tempdir.path())
         .args(&["dylint", "--all"])
         .assert()
         .success()

--- a/driver/.cargo/config.toml
+++ b/driver/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target-dir = "../target"

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -16,3 +16,8 @@ serde_json = "1.0.66"
 dylint_internal = { version = "=1.0.1", path = "../internal" }
 
 [workspace]
+
+[workspace.metadata.dylint]
+libraries = [
+    { path = "../examples/*" },
+]

--- a/dylint/src/lib.rs
+++ b/dylint/src/lib.rs
@@ -467,23 +467,16 @@ mod test {
     #![allow(clippy::unwrap_used)]
 
     use super::*;
-    use dylint_internal::examples;
+    use dylint_internal::{cargo::current_metadata, examples};
     use lazy_static::lazy_static;
-    use std::env::{join_paths, set_var};
+    use std::env::set_var;
     use test_env_log::test;
 
     lazy_static! {
         static ref NAME_TOOLCHAIN_MAP: NameToolchainMap = {
             examples::build().unwrap();
-            let dylint_library_path = join_paths(examples::iter().unwrap().map(|example| {
-                example
-                    .unwrap()
-                    .join("target")
-                    .join("debug")
-                    .to_string_lossy()
-                    .to_string()
-            }))
-            .unwrap();
+            let metadata = current_metadata().unwrap();
+            let dylint_library_path = metadata.target_directory.join("debug");
             set_var(env::DYLINT_LIBRARY_PATH, dylint_library_path);
             name_toolchain_map(&Dylint {
                 no_metadata: true,

--- a/dylint/src/metadata.rs
+++ b/dylint/src/metadata.rs
@@ -133,9 +133,9 @@ fn maybe_build_packages(
     // files sooner.
 
     // smoelius: Why are we doing this complicated dance at all? Because we want to leverage Cargo's
-    // package cache. But we also want to support git repositories with libraries that use different
-    // compiler versions. And we have to work around the fact that "all projects within a workspace
-    // are intended to be built with the same version of the compiler"
+    // download cache. But we also want to support git repositories with libraries that use
+    // different compiler versions. And we have to work around the fact that "all projects within a
+    // workspace are intended to be built with the same version of the compiler"
     // (https://github.com/rust-lang/rustup/issues/1399#issuecomment-383376082).
 
     let package_root_ids = paths

--- a/examples/allow_clippy/.cargo/config.toml
+++ b/examples/allow_clippy/.cargo/config.toml
@@ -1,3 +1,6 @@
+[build]
+target-dir = "../../target"
+
 [target.x86_64-apple-darwin]
 linker = "dylint-link"
 

--- a/examples/allow_clippy/Cargo.toml
+++ b/examples/allow_clippy/Cargo.toml
@@ -23,3 +23,9 @@ dylint_testing = { path = "../../utils/testing", features = ["dylint_driver_loca
 rustc_private = true
 
 [workspace]
+
+[workspace.metadata.dylint]
+libraries = [
+    { path = "../*" },
+]
+

--- a/examples/clippy/.cargo/config.toml
+++ b/examples/clippy/.cargo/config.toml
@@ -1,3 +1,6 @@
+[build]
+target-dir = "../../target"
+
 [target.x86_64-apple-darwin]
 linker = "dylint-link"
 

--- a/examples/clippy/Cargo.toml
+++ b/examples/clippy/Cargo.toml
@@ -32,3 +32,8 @@ dylint_testing = { path = "../../utils/testing", features = ["dylint_driver_loca
 rustc_private = true
 
 [workspace]
+
+[workspace.metadata.dylint]
+libraries = [
+    { path = "../*" },
+]

--- a/examples/env_literal/.cargo/config.toml
+++ b/examples/env_literal/.cargo/config.toml
@@ -1,3 +1,6 @@
+[build]
+target-dir = "../../target"
+
 [target.x86_64-apple-darwin]
 linker = "dylint-link"
 

--- a/examples/env_literal/Cargo.toml
+++ b/examples/env_literal/Cargo.toml
@@ -22,3 +22,8 @@ dylint_testing = { path = "../../utils/testing", features = ["dylint_driver_loca
 rustc_private = true
 
 [workspace]
+
+[workspace.metadata.dylint]
+libraries = [
+    { path = "../*" },
+]

--- a/examples/path_separator_in_string_literal/.cargo/config.toml
+++ b/examples/path_separator_in_string_literal/.cargo/config.toml
@@ -1,3 +1,6 @@
+[build]
+target-dir = "../../target"
+
 [target.x86_64-apple-darwin]
 linker = "dylint-link"
 

--- a/examples/path_separator_in_string_literal/Cargo.toml
+++ b/examples/path_separator_in_string_literal/Cargo.toml
@@ -22,3 +22,8 @@ dylint_testing = { path = "../../utils/testing", features = ["dylint_driver_loca
 rustc_private = true
 
 [workspace]
+
+[workspace.metadata.dylint]
+libraries = [
+    { path = "../*" },
+]

--- a/examples/question_mark_in_expression/.cargo/config.toml
+++ b/examples/question_mark_in_expression/.cargo/config.toml
@@ -1,3 +1,6 @@
+[build]
+target-dir = "../../target"
+
 [target.x86_64-apple-darwin]
 linker = "dylint-link"
 

--- a/examples/question_mark_in_expression/Cargo.toml
+++ b/examples/question_mark_in_expression/Cargo.toml
@@ -33,3 +33,8 @@ dylint_testing = { path = "../../utils/testing", features = ["dylint_driver_loca
 rustc_private = true
 
 [workspace]
+
+[workspace.metadata.dylint]
+libraries = [
+    { path = "../*" },
+]

--- a/examples/try_io_result/.cargo/config.toml
+++ b/examples/try_io_result/.cargo/config.toml
@@ -1,3 +1,6 @@
+[build]
+target-dir = "../../target"
+
 [target.x86_64-apple-darwin]
 linker = "dylint-link"
 

--- a/examples/try_io_result/Cargo.toml
+++ b/examples/try_io_result/Cargo.toml
@@ -28,3 +28,8 @@ dylint_testing = { path = "../../utils/testing", features = ["dylint_driver_loca
 rustc_private = true
 
 [workspace]
+
+[workspace.metadata.dylint]
+libraries = [
+    { path = "../*" },
+]

--- a/internal/src/cargo.rs
+++ b/internal/src/cargo.rs
@@ -1,7 +1,5 @@
-use crate::env::{self, var};
 use anyhow::{anyhow, ensure, Result};
 use cargo_metadata::{Metadata, MetadataCommand, Package, PackageId};
-use std::path::Path;
 
 #[must_use]
 pub fn build() -> crate::Command {
@@ -24,14 +22,9 @@ fn cargo(subcommand: &str) -> crate::Command {
     command
 }
 
-pub fn metadata() -> Result<Metadata> {
-    let manifest_dir = var(env::CARGO_MANIFEST_DIR)?;
-    let manifest_path = Path::new(&manifest_dir).join("Cargo.toml");
-    MetadataCommand::new()
-        .manifest_path(manifest_path)
-        .no_deps()
-        .exec()
-        .map_err(Into::into)
+/// Get metadata based on the current directory.
+pub fn current_metadata() -> Result<Metadata> {
+    MetadataCommand::new().no_deps().exec().map_err(Into::into)
 }
 
 pub fn root_package(metadata: &Metadata) -> Result<Package> {

--- a/internal/src/env.rs
+++ b/internal/src/env.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Result};
 
 pub const CARGO_MANIFEST_DIR: &str = "CARGO_MANIFEST_DIR";
 pub const CARGO_PKG_NAME: &str = "CARGO_PKG_NAME";
+pub const CARGO_TARGET_DIR: &str = "CARGO_TARGET_DIR";
 pub const CARGO_TERM_COLOR: &str = "CARGO_TERM_COLOR";
 pub const CLIPPY_DISABLE_DOCS_LINKS: &str = "CLIPPY_DISABLE_DOCS_LINKS";
 pub const CLIPPY_DRIVER_PATH: &str = "CLIPPY_DRIVER_PATH";

--- a/internal/src/testing.rs
+++ b/internal/src/testing.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cargo::{metadata, package},
+    cargo::{current_metadata, package},
     sed::find_and_replace,
 };
 use anyhow::{anyhow, Result};
@@ -35,7 +35,7 @@ pub fn isolate(path: &Path) -> Result<()> {
 // packages in this repository. The function `use_local_packages` patches a workspace's `Cargo.toml`
 // file to do so.
 fn use_local_packages(path: &Path) -> Result<()> {
-    let metadata = metadata()?;
+    let metadata = current_metadata()?;
 
     let mut file = OpenOptions::new()
         .write(true)

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -23,8 +23,6 @@ EXAMPLES="$(echo "$EXAMPLES" | sed 's/\<allow_clippy\>[[:space:]]*//')"
 # wreaks havoc.
 EXAMPLES="$(echo "$EXAMPLES" | sed 's/\<try_io_result\>[[:space:]]*//')"
 
-# smoelius: Put '.' first to ensure all libraries are built. (See the hack regarding
-# `DYLINT_LIBRARY_PATH` below.)
 DIRS=". driver"
 for EXAMPLE in $EXAMPLES; do
     DIRS="$DIRS examples/$EXAMPLE"
@@ -35,15 +33,12 @@ done
 EXAMPLES="$(echo "$EXAMPLES" | sed 's/\<clippy\>[[:space:]]*//')"
 
 for DIR in $DIRS; do
-    unset DYLINT_LIBRARY_PATH
-    if [[ "$DIR" != '.' ]]; then
-        export DYLINT_LIBRARY_PATH="$(echo target/dylint/*/release | xargs readlink -f | tr '\n' ':' | head -c -1)"
-    fi
-
     pushd "$DIR"
     for LINTS in "$EXAMPLES" clippy; do
         # smoelius: `cargo clean` can't be used here because it would remove cargo-dylint.
-        rm -rf target/debug/deps
+        # smoelius: The commented command doesn't do anything now that all workspaes in the
+        # repository share a top-level target directory. Is the command still necesary?
+        # rm -rf target/debug/deps
 
         unset DYLINT_RUSTFLAGS
         if [[ "$LINTS" = clippy ]]; then


### PR DESCRIPTION
This has numerous benefits:

* Build times are faster, because all of the workspaces share a `deps` directory.
* `cargo clean` now works.
* It simplifies the script used to lint the repository.

Thanks to @thomaseizinger for showing us this was possible.