### PR TITLE
Fix Clap Dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
 name = "assert_cmd"
@@ -74,9 +74,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "2da1976d75adbe5fbc88130ecd119529cf1cc6a93ae1546d8696ee66f0d21af1"
 
 [[package]]
 name = "bitmaps"
@@ -179,7 +179,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "cargo_metadata",
- "clap 3.0.0-beta.2",
+ "clap 3.0.0-beta.4",
  "dylint",
  "dylint_internal",
  "env_logger 0.9.0",
@@ -266,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
+checksum = "fcd70aa5597dbc42f7217a543f9ef2768b2ef823ba29036072d30e1d88e98406"
 dependencies = [
  "atty",
  "bitflags",
@@ -278,16 +278,15 @@ dependencies = [
  "os_str_bytes",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.12.1",
- "unicode-width",
+ "textwrap 0.14.2",
  "vec_map",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
+checksum = "0b5bb0d655624a0b8770d1c178fb8ffcb1f91cc722cb08f451e3dc72465421ac"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -589,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
+checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
 dependencies = [
  "cfg-if",
  "libc",
@@ -684,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.20"
+version = "0.13.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9831e983241f8c5591ed53f17d874833e2fa82cac2625f3888c50cbfe136cba"
+checksum = "659cd14835e75b64d9dba5b660463506763cf0aa6cb640aeeb0e98d841093490"
 dependencies = [
  "bitflags",
  "libc",
@@ -876,15 +875,15 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.21+1.1.0"
+version = "0.12.22+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86271bacd72b2b9e854c3dcfb82efd538f15f870e4c11af66900effb462f6825"
+checksum = "89c53ac117c44f7042ad8d8f5681378dfbc6010e49ec2c0d1f11dfedc7a4a1c3"
 dependencies = [
  "cc",
  "libc",
@@ -941,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -1045,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "2.4.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
+checksum = "6acbef58a60fe69ab50510a55bc8cdd4d6cf2283d27ad338f54cb52747a9cf2d"
 
 [[package]]
 name = "percent-encoding"
@@ -1412,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.35"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d779dc6aeff029314570f666ec83f19df7280bb36ef338442cfa8c604021b80"
+checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
 dependencies = [
  "filetime",
  "libc",
@@ -1489,9 +1488,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 dependencies = [
  "unicode-width",
 ]
@@ -1543,12 +1542,9 @@ checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
-dependencies = [
- "matches",
-]
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
 
 [[package]]
 name = "unicode-normalization"

--- a/cargo-dylint/Cargo.toml
+++ b/cargo-dylint/Cargo.toml
@@ -9,8 +9,7 @@ repository = "https://github.com/trailofbits/dylint"
 
 [dependencies]
 anyhow = "1.0.42"
-# MinerSebas: Remove the Pining after Clap releases a non-beta Release.
-clap = "=3.0.0-beta.4"
+clap = "3.0.0-beta.4"
 env_logger = "0.9.0"
 
 dylint = { version = "=1.0.2", path = "../dylint", features = ["dylint_driver_local"] }

--- a/cargo-dylint/Cargo.toml
+++ b/cargo-dylint/Cargo.toml
@@ -9,7 +9,8 @@ repository = "https://github.com/trailofbits/dylint"
 
 [dependencies]
 anyhow = "1.0.42"
-clap = "3.0.0-beta.2"
+# MinerSebas: Remove the Pining after Clap releases a non-beta Release.
+clap = "=3.0.0-beta.4"
 env_logger = "0.9.0"
 
 dylint = { version = "=1.0.2", path = "../dylint", features = ["dylint_driver_local"] }

--- a/cargo-dylint/src/main.rs
+++ b/cargo-dylint/src/main.rs
@@ -45,7 +45,6 @@ pub struct Dylint {
     pub all: bool,
 
     #[clap(
-        multiple = true,
         number_of_values = 1,
         long = "lib",
         value_name = "name",
@@ -80,7 +79,6 @@ pub struct Dylint {
     pub no_metadata: bool,
 
     #[clap(
-        multiple = true,
         number_of_values = 1,
         short,
         long = "package",
@@ -90,7 +88,6 @@ pub struct Dylint {
     pub packages: Vec<String>,
 
     #[clap(
-        multiple = true,
         number_of_values = 1,
         long = "path",
         value_name = "path",

--- a/cargo-dylint/src/main.rs
+++ b/cargo-dylint/src/main.rs
@@ -45,6 +45,7 @@ pub struct Dylint {
     pub all: bool,
 
     #[clap(
+        multiple_occurrences = true,
         number_of_values = 1,
         long = "lib",
         value_name = "name",
@@ -79,6 +80,7 @@ pub struct Dylint {
     pub no_metadata: bool,
 
     #[clap(
+        multiple_occurrences = true,
         number_of_values = 1,
         short,
         long = "package",
@@ -88,6 +90,7 @@ pub struct Dylint {
     pub packages: Vec<String>,
 
     #[clap(
+        multiple_occurrences = true,
         number_of_values = 1,
         long = "path",
         value_name = "path",

--- a/examples/allow_clippy/Cargo.lock
+++ b/examples/allow_clippy/Cargo.lock
@@ -107,16 +107,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.52"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=rust-1.52.0#6ed6f1e6a1a8f414ba7e6d9b8222e7e5a1686e42"
+version = "0.1.54"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=531bfc83#531bfc83b6f24dda7d16d3a2f349c9d85d172131"
 dependencies = [
  "if_chain",
  "itertools",
  "regex-syntax",
  "rustc-semver",
  "serde",
- "smallvec",
- "toml",
  "unicode-normalization",
 ]
 
@@ -682,12 +680,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
-
-[[package]]
 name = "syn"
 version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,15 +751,6 @@ name = "tinyvec_macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
-
-[[package]]
-name = "toml"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "unicode-bidi"

--- a/examples/allow_clippy/Cargo.toml
+++ b/examples/allow_clippy/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # smoelius: `allow_clippy` is intentionally held back.
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "rust-1.52.0"}
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "531bfc83"}
 if_chain = "1.0.1"
 
 dylint_linting = { path = "../../utils/linting" }

--- a/examples/allow_clippy/rust-toolchain
+++ b/examples/allow_clippy/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2021-03-11"
+channel = "nightly-2021-05-20"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/examples/allow_clippy/src/allow_clippy.rs
+++ b/examples/allow_clippy/src/allow_clippy.rs
@@ -1,4 +1,4 @@
-use clippy_utils::span_lint_and_sugg;
+use clippy_utils::diagnostics::span_lint_and_sugg;
 use if_chain::if_chain;
 use rustc_ast::{Attribute, NestedMetaItem};
 use rustc_errors::Applicability;

--- a/scripts/toolchain_from_version.sh
+++ b/scripts/toolchain_from_version.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "$0: expect one argument: Rust version" >&2
+    exit 1
+fi
+
+VERSION="$1"
+
+TMP="$(mktemp -d)"
+
+git clone --branch rust-"$VERSION" 'https://github.com/rust-lang/rust-clippy' "$TMP" 2>/dev/null
+cd "$TMP"
+sed -n 's/^channel = "\([^"]*\)"$/\1/;T;p' rust-toolchain


### PR DESCRIPTION
The latest update of Clap breaks the installation of cargo-dylint ([Concrete Case](https://github.com/trailofbits/dylint-template/pull/6/checks?check_run_id=3333730574)).

The problem was fixed by removing the `multiple = true,` inside the derive annotations.
I also pinned the clap dependency to avoid further breakage. (Cargo sees Beta releases as Semver compatible)

A downside to the move to Clap `3.0.0-beta.4` is that it uses the [Attributes can invoke function-like macros](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html#attributes-can-invoke-function-like-macros) Feature of Rust 1.54, which prevents the `allow-clippy` Lint from linting cargo-dylint correctly.

Either `allow-clippy` should be moved to a more recent rust version or pin clap to `3.0.0-beta.2` instead.