### PR TITLE
Hide dylint_version() in docs

### DIFF
--- a/utils/linting/src/lib.rs
+++ b/utils/linting/src/lib.rs
@@ -9,8 +9,8 @@ macro_rules! dylint_library {
         #[allow(unused_extern_crates)]
         extern crate rustc_driver;
 
-        #[no_mangle]
         #[doc(hidden)]
+        #[no_mangle]
         pub extern "C" fn dylint_version() -> *mut std::os::raw::c_char {
             std::ffi::CString::new($crate::DYLINT_VERSION)
                 .unwrap()

--- a/utils/linting/src/lib.rs
+++ b/utils/linting/src/lib.rs
@@ -10,6 +10,7 @@ macro_rules! dylint_library {
         extern crate rustc_driver;
 
         #[no_mangle]
+        #[doc(hidden)]
         pub extern "C" fn dylint_version() -> *mut std::os::raw::c_char {
             std::ffi::CString::new($crate::DYLINT_VERSION)
                 .unwrap()


### PR DESCRIPTION
While uploading the Docs for my Crate, I noticed that I can't hide the `dylint_version()` Function inside the docs.
https://minersebas.github.io/bevy_lint/bevy_lint/index.html#functions

This adds the `#[doc(hidden)]` Attribute inside the `dylint_library!` Macro, to hide the function.