### PR TITLE
Updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
 
     runs-on: ${{ matrix.environment }}
 
+    defaults:
+      run:
+        shell: bash
+
     steps:
       - uses: actions/checkout@v2
 
@@ -59,6 +63,19 @@ jobs:
 
       - name: Test
         run: cargo test --workspace
+
+      - name: Test example documentation
+        # smoelius: The `cdylib` -> `lib` trick is due to @MinerSebas.
+        run: |
+          for X in examples/*; do
+            if [[ ! -d "$X" ]]; then
+              continue
+            fi
+            pushd "$X"
+            sed -i.bak 's/"cdylib"/"lib"/g' Cargo.toml
+            cargo test --doc
+            popd
+          done
 
   coverage:
     runs-on: ubuntu-latest

--- a/cargo-dylint/src/main.rs
+++ b/cargo-dylint/src/main.rs
@@ -47,6 +47,9 @@ pub struct Dylint {
     #[clap(long, hidden = true)]
     pub isolate: bool,
 
+    #[clap(long, about = "Continue if `cargo check` fails")]
+    pub keep_going: bool,
+
     #[clap(
         multiple_occurrences = true,
         number_of_values = 1,
@@ -146,6 +149,7 @@ impl From<Dylint> for dylint::Dylint {
         let Dylint {
             all,
             isolate,
+            keep_going,
             libs,
             list,
             manifest_path,
@@ -164,6 +168,7 @@ impl From<Dylint> for dylint::Dylint {
         Self {
             all,
             isolate,
+            keep_going,
             libs,
             list,
             manifest_path,

--- a/cargo-dylint/tests/dylint_driver_path.rs
+++ b/cargo-dylint/tests/dylint_driver_path.rs
@@ -31,7 +31,7 @@ fn dylint_driver_path() {
     let toolchain_path = toolchain_path(tempdir.path()).unwrap();
     let toolchain = toolchain_path.iter().last().unwrap();
     let mut command = dylint_internal::driver(
-        &toolchain.to_string_lossy().to_string(),
+        &toolchain.to_string_lossy(),
         &dylint_driver_path.join(toolchain).join("dylint-driver"),
     )
     .unwrap();

--- a/cargo-dylint/tests/package_options.rs
+++ b/cargo-dylint/tests/package_options.rs
@@ -14,12 +14,7 @@ fn new_package() {
 
     std::process::Command::cargo_bin("cargo-dylint")
         .unwrap()
-        .args(&[
-            "dylint",
-            "--new",
-            &path.to_string_lossy().to_string(),
-            "--isolate",
-        ])
+        .args(&["dylint", "--new", &path.to_string_lossy(), "--isolate"])
         .assert()
         .success();
 
@@ -51,7 +46,7 @@ fn upgrade_package() {
         .args(&[
             "dylint",
             "--upgrade",
-            &tempdir.path().to_string_lossy().to_string(),
+            &tempdir.path().to_string_lossy(),
             "--rust-version",
             &rust_version.to_string(),
         ])
@@ -72,11 +67,7 @@ fn upgrade_package() {
 
     std::process::Command::cargo_bin("cargo-dylint")
         .unwrap()
-        .args(&[
-            "dylint",
-            "--upgrade",
-            &tempdir.path().to_string_lossy().to_string(),
-        ])
+        .args(&["dylint", "--upgrade", &tempdir.path().to_string_lossy()])
         .assert()
         .success();
 

--- a/dylint/src/metadata.rs
+++ b/dylint/src/metadata.rs
@@ -313,6 +313,7 @@ fn target_dir(metadata: &Metadata, package_root: &Path, _package_id: PackageId) 
     Ok(metadata
         .target_directory
         .join("dylint")
+        .join("libraries")
         .join(toolchain)
         // .join(pkg_dir(package_root, package_id))
         .into())

--- a/examples/allow_clippy/README.md
+++ b/examples/allow_clippy/README.md
@@ -18,7 +18,7 @@ Bad:
 Good:
 
 ```rust
-#[deny(clippy::restriction, clippy::style, clippy::pedantic, clippy::complexity, clippy::perf, clippy::cargo, clippy::nursery)]
+#![deny(clippy::restriction, clippy::style, clippy::pedantic, clippy::complexity, clippy::perf, clippy::cargo, clippy::nursery)]
 ```
 
 Returns the lint name if it is clippy lint.

--- a/examples/allow_clippy/src/allow_clippy.rs
+++ b/examples/allow_clippy/src/allow_clippy.rs
@@ -24,7 +24,7 @@ declare_lint! {
     ///
     /// Good:
     /// ```rust
-    /// #[deny(clippy::restriction, clippy::style, clippy::pedantic, clippy::complexity, clippy::perf, clippy::cargo, clippy::nursery)]
+    /// #![deny(clippy::restriction, clippy::style, clippy::pedantic, clippy::complexity, clippy::perf, clippy::cargo, clippy::nursery)]
     /// ```
     pub ALLOW_CLIPPY,
     Warn,

--- a/examples/path_separator_in_string_literal/src/path_separator_in_string_literal.rs
+++ b/examples/path_separator_in_string_literal/src/path_separator_in_string_literal.rs
@@ -18,11 +18,17 @@ declare_lint! {
     /// **Example:**
     ///
     /// ```rust
+    /// # use std::path::PathBuf;
+    /// # let _ =
     /// PathBuf::from("../target")
+    /// # ;
     /// ```
     /// Use instead:
     /// ```rust
+    /// # use std::path::PathBuf;
+    /// # let _ =
     /// PathBuf::from("..").join("target")
+    /// # ;
     /// ```
     pub PATH_SEPARATOR_IN_STRING_LITERAL,
     Warn,

--- a/examples/question_mark_in_expression/README.md
+++ b/examples/question_mark_in_expression/README.md
@@ -10,12 +10,12 @@ the outermost operator in an expression.
 **Example:**
 
 ```rust
-Ok(std::path::PathBuf::from(&std::env::var("PWD")?))
+Ok(PathBuf::from(&var("PWD")?))
 ```
 
 Use instead:
 
 ```rust
-let val = std::env::var("PWD")?;
-Ok(std::path::PathBuf::from(&val))
+let val = var("PWD")?;
+Ok(PathBuf::from(&val))
 ```

--- a/examples/question_mark_in_expression/src/question_mark_in_expression.rs
+++ b/examples/question_mark_in_expression/src/question_mark_in_expression.rs
@@ -15,12 +15,18 @@ declare_lint! {
     /// **Example:**
     ///
     /// ```rust
-    /// Ok(std::path::PathBuf::from(&std::env::var("PWD")?))
+    /// # use std::{env::{var, VarError}, path::PathBuf};
+    /// # let _: Result<PathBuf, VarError> = (|| {
+    /// Ok(PathBuf::from(&var("PWD")?))
+    /// # })();
     /// ```
     /// Use instead:
     /// ```rust
-    /// let val = std::env::var("PWD")?;
-    /// Ok(std::path::PathBuf::from(&val))
+    /// # use std::{env::{var, VarError}, path::PathBuf};
+    /// # let _: Result<PathBuf, VarError> = (|| {
+    /// let val = var("PWD")?;
+    /// Ok(PathBuf::from(&val))
+    /// # })();
     /// ```
     pub QUESTION_MARK_IN_EXPRESSION,
     Warn,

--- a/examples/try_io_result/src/try_io_result.rs
+++ b/examples/try_io_result/src/try_io_result.rs
@@ -18,6 +18,7 @@ declare_lint! {
     /// **Example:**
     ///
     /// ```rust
+    /// # use std::fs::File;
     /// fn foo() -> std::io::Result<()> {
     ///     let _ = File::open("/dev/null")?;
     ///     Ok(())
@@ -25,6 +26,7 @@ declare_lint! {
     /// ```
     /// Use instead:
     /// ```rust
+    /// # use std::fs::File;
     /// use anyhow::Context;
     /// fn foo() -> anyhow::Result<()> {
     ///         let _ = File::open("/dev/null").with_context(|| "could not open `/dev/null`")?;

--- a/scripts/update_example_READMEs.sh
+++ b/scripts/update_example_READMEs.sh
@@ -36,7 +36,7 @@ mv "$TMP" README.md
 prettier --write README.md
 
 for EXAMPLE in *; do
-    if [[ ! -d "$EXAMPLE" || "$EXAMPLE" = src ]]; then
+    if [[ ! -d "$EXAMPLE" ]]; then
         continue
     fi
 
@@ -46,6 +46,7 @@ for EXAMPLE in *; do
         echo "# $EXAMPLE"
         echo
         cat src/*.rs |
+        sed '\,^[[:space:]]*///[[:space:]]\?#[^![],d' |
         sed -n 's,^[[:space:]]*///[[:space:]]\?\(.*\)$,\1,;T;p'
     ) > README.md
 


### PR DESCRIPTION
* Separate compilation artifacts by toolchain
* Add `--keep-going` option
* Test example documentation in CI
* Eliminate some unnecessary `.to_string()` calls