### PR TITLE
Fix "unreachable statement" warning on Windows

### DIFF
--- a/dylint/src/lib.rs
+++ b/dylint/src/lib.rs
@@ -72,6 +72,7 @@ pub fn run(opts: &Dylint) -> Result<()> {
         #[cfg(not(unix))]
         bail!("`--bisect` is supported only on Unix platforms");
 
+        #[cfg(unix)]
         warn(opts, "`--bisect` is experimental");
     }
 


### PR DESCRIPTION
Fixes #179