### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ In the above example, the libraries are found via [workspace metadata](#workspac
 
 ### Writing lints
 
-You can start writing your own Dylint libraries by forking the [`dylint-template`](https://github.com/trailofbits/dylint-template) repository. The repository produces a loadable library right out of the box. You can verify this as follows:
+You can start writing your own Dylint library by running `cargo dylint --new new_lint_name`. Doing so will produce a loadable library right out of the box. You can verify this as follows:
 
 ```sh
-git clone https://github.com/trailofbits/dylint-template
-cd dylint-template
+cargo dylint --new new_lint_name
+cd new_lint_name
 cargo build
-DYLINT_LIBRARY_PATH=$PWD/target/debug cargo dylint fill_me_in --list
+DYLINT_LIBRARY_PATH=$PWD/target/debug cargo dylint new_lint_name --list
 ```
 
 All you have to do is implement the [`LateLintPass`](https://doc.rust-lang.org/stable/nightly-rustc/rustc_lint/trait.LateLintPass.html) trait and accommodate the symbols asking to be filled in.


### PR DESCRIPTION
Update instructions to use `cargo dylint --new` instead of cloning `dylint-template`.