### PR TITLE
Revert 6c71daa

### DIFF
--- a/cargo-dylint/tests/list.rs
+++ b/cargo-dylint/tests/list.rs
@@ -130,7 +130,8 @@ fn one_name_multiple_paths() {
         );
 }
 
-#[test]
+// #[test]
+#[allow(dead_code)]
 fn canonical_path() {
     let tempdir = tempdir().unwrap();
 
@@ -207,7 +208,6 @@ fn list_by_path() {
 
 // smoelius: For the tests to pass on OSX, the paths have to be canonicalized, because `/var` is
 // symlinked to `/private/var`.
-// smoelius: Now that `name_toolchain_map` stores canonical paths, is this still necessary?
 fn target_debug(path: &Path) -> Result<PathBuf> {
     let metadata = MetadataCommand::new().current_dir(path).no_deps().exec()?;
     let debug_dir = metadata.target_directory.join("debug");

--- a/dylint/src/name_toolchain_map.rs
+++ b/dylint/src/name_toolchain_map.rs
@@ -105,10 +105,7 @@ fn dylint_libraries_in(
         .map(move |entry| -> Result<Option<(String, String, PathBuf)>> {
             let entry = entry
                 .with_context(|| format!("`read_dir` failed for `{}`", path.to_string_lossy()))?;
-            let path = entry
-                .path()
-                .canonicalize()
-                .with_context(|| format!("Could not canonicalize {:?}", path))?;
+            let path = entry.path();
 
             Ok(if let Some(filename) = path.file_name() {
                 parse_filename(&filename.to_string_lossy())


### PR DESCRIPTION
I thought 6c71daa was needed to enabled 1ad7da7, but that turned out not
to be the case. I may reenable 6c71daa after I have had more time to
think about what the "right" behavior should be.