### PR TITLE
Attempt to build `dylint_linting` on `docs.rs`

### DIFF
--- a/utils/linting/Cargo.toml
+++ b/utils/linting/Cargo.toml
@@ -17,6 +17,9 @@ toml = "0.5.9"
 
 dylint_internal = { version = "=2.1.1", path = "../../internal" }
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "docsrs"]
+
 [workspace]
 
 [workspace.metadata.dylint]

--- a/utils/linting/src/lib.rs
+++ b/utils/linting/src/lib.rs
@@ -1,8 +1,11 @@
 #![doc = include_str!("../README.md")]
-#![feature(rustc_private)]
+#![cfg_attr(not(docsrs), feature(rustc_private))]
 #![warn(unused_extern_crates)]
 
+#[cfg(not(docsrs))]
 extern crate rustc_session;
+
+#[cfg(not(docsrs))]
 extern crate rustc_span;
 
 use cargo_metadata::{Metadata, MetadataCommand};


### PR DESCRIPTION
Following the switch to `nightly`, `dylint_linting` stopped building on `docs.rs`. This is an attempt to fix that.