### PR TITLE
Remove `dirs` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,7 +744,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/examples/general/await_holding_span_guard/Cargo.lock
+++ b/examples/general/await_holding_span_guard/Cargo.lock
@@ -278,7 +278,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/examples/general/crate_wide_allow/Cargo.lock
+++ b/examples/general/crate_wide_allow/Cargo.lock
@@ -316,7 +316,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/examples/general/env_cargo_path/Cargo.lock
+++ b/examples/general/env_cargo_path/Cargo.lock
@@ -268,7 +268,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/examples/general/non_local_effect_before_error_return/Cargo.lock
+++ b/examples/general/non_local_effect_before_error_return/Cargo.lock
@@ -274,7 +274,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/examples/general/non_thread_safe_call_in_test/Cargo.lock
+++ b/examples/general/non_thread_safe_call_in_test/Cargo.lock
@@ -268,7 +268,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/examples/restriction/collapsible_unwrap/Cargo.lock
+++ b/examples/restriction/collapsible_unwrap/Cargo.lock
@@ -280,7 +280,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/examples/restriction/const_path_join/Cargo.lock
+++ b/examples/restriction/const_path_join/Cargo.lock
@@ -280,7 +280,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/examples/restriction/env_literal/Cargo.lock
+++ b/examples/restriction/env_literal/Cargo.lock
@@ -268,7 +268,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/examples/restriction/inconsistent_qualification/Cargo.lock
+++ b/examples/restriction/inconsistent_qualification/Cargo.lock
@@ -268,7 +268,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/examples/restriction/misleading_variable_name/Cargo.lock
+++ b/examples/restriction/misleading_variable_name/Cargo.lock
@@ -268,7 +268,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/examples/restriction/missing_doc_comment_openai/Cargo.lock
+++ b/examples/restriction/missing_doc_comment_openai/Cargo.lock
@@ -298,7 +298,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/examples/restriction/question_mark_in_expression/Cargo.lock
+++ b/examples/restriction/question_mark_in_expression/Cargo.lock
@@ -268,7 +268,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/examples/restriction/ref_aware_redundant_closure_for_method_calls/Cargo.lock
+++ b/examples/restriction/ref_aware_redundant_closure_for_method_calls/Cargo.lock
@@ -268,7 +268,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/examples/restriction/suboptimal_pattern/Cargo.lock
+++ b/examples/restriction/suboptimal_pattern/Cargo.lock
@@ -268,7 +268,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/examples/restriction/try_io_result/Cargo.lock
+++ b/examples/restriction/try_io_result/Cargo.lock
@@ -268,7 +268,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/examples/supplementary/overscoped_allow/Cargo.lock
+++ b/examples/supplementary/overscoped_allow/Cargo.lock
@@ -303,7 +303,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/examples/supplementary/redundant_reference/Cargo.lock
+++ b/examples/supplementary/redundant_reference/Cargo.lock
@@ -268,7 +268,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/examples/supplementary/unnecessary_borrow_mut/Cargo.lock
+++ b/examples/supplementary/unnecessary_borrow_mut/Cargo.lock
@@ -268,7 +268,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/examples/supplementary/unnecessary_conversion_for_trait/Cargo.lock
+++ b/examples/supplementary/unnecessary_conversion_for_trait/Cargo.lock
@@ -268,7 +268,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/examples/testing/clippy/Cargo.lock
+++ b/examples/testing/clippy/Cargo.lock
@@ -320,7 +320,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/examples/testing/straggler/Cargo.lock
+++ b/examples/testing/straggler/Cargo.lock
@@ -268,7 +268,6 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
- "dirs",
  "git2",
  "home",
  "if_chain",

--- a/internal/Cargo.toml
+++ b/internal/Cargo.toml
@@ -14,7 +14,6 @@ if_chain = "1.0"
 ansi_term = { version = "0.12", optional = true }
 atty = { version = "0.2", optional = true }
 cargo_metadata = { version = "0.15", optional = true }
-dirs = { version = "5.0", optional = true }
 git2 = { version = "0.16", optional = true }
 home = { version = "0.5", optional = true }
 log = { version = "0.4", optional = true }
@@ -28,7 +27,7 @@ walkdir = { version = "2.3", optional = true }
 toml_edit = "0.19"
 
 [features]
-cargo = ["ansi_term", "atty", "cargo_metadata", "command", "dirs", "home"]
+cargo = ["ansi_term", "atty", "cargo_metadata", "command", "home"]
 clippy_utils = ["semver", "toml_edit"]
 command = ["log"]
 examples = ["cargo", "rustup", "walkdir"]


### PR DESCRIPTION
The need for `dirs` went away with #604 (I think).