### PR TITLE
Fix bug in `misleading_variable_name`

### DIFF
--- a/examples/restriction/misleading_variable_name/src/lib.rs
+++ b/examples/restriction/misleading_variable_name/src/lib.rs
@@ -65,6 +65,8 @@ impl<'tcx> LateLintPass<'tcx> for MisleadingVariableName {
             let expr = peel_try_unwrap_and_similar(cx, init);
             if let Some(callee_def_id) = callee_def_id(cx, expr);
             let module_def_id = parent_module(cx.tcx, callee_def_id);
+            // smoelius: Don't flag functions/types defined in the same module as the call.
+            if module_def_id != cx.tcx.parent_module(stmt.hir_id).to_def_id();
             let child_types = module_public_child_types(cx.tcx, module_def_id);
             if let Some((child_ty_name, child_ty)) = child_types.get(ident.name.as_str());
             let init_ty = erase_substs(

--- a/examples/restriction/misleading_variable_name/ui/main.rs
+++ b/examples/restriction/misleading_variable_name/ui/main.rs
@@ -79,3 +79,16 @@ fn main() -> Result<()> {
 
     Ok(())
 }
+
+// smoelius: Don't flag functions/types defined in the same module as the call.
+mod same_mod {
+    pub struct Bar;
+
+    pub fn foo() -> bool {
+        false
+    }
+
+    fn baz() {
+        let bar = foo();
+    }
+}


### PR DESCRIPTION
Don't flag functions/types defined in the same module as the call.