### PR TITLE
Fix false negative in `inconsistent_qualification`

### DIFF
--- a/dylint/src/error.rs
+++ b/dylint/src/error.rs
@@ -50,7 +50,7 @@ pub type ColorizedResult<T> = Result<T, ColorizedError<anyhow::Error>>;
 #[allow(clippy::expect_used)]
 pub fn warn(opts: &crate::Dylint, message: &str) {
     if !opts.quiet {
-        // smoelius: Writing directly to `stderr` avoids capture by `libtest`.
+        // smoelius: Writing directly to `stderr` prevents capture by `libtest`.
         std::io::stderr()
             .write_fmt(format_args!(
                 "{}: {message}\n",

--- a/examples/restriction/derive_opportunity/src/lib.rs
+++ b/examples/restriction/derive_opportunity/src/lib.rs
@@ -271,7 +271,7 @@ impl<'tcx> DeriveOpportunity<'tcx> {
 }
 
 fn all_params_are_lifetimes(tcx: ty::TyCtxt<'_>, trait_id: DefId) -> bool {
-    std::iter::once(trait_id)
+    iter::once(trait_id)
         .chain(super_traits_of(tcx, trait_id))
         .all(|trait_id| {
             let generics = tcx.generics_of(trait_id);

--- a/examples/restriction/inconsistent_qualification/ui/main.rs
+++ b/examples/restriction/inconsistent_qualification/ui/main.rs
@@ -72,3 +72,44 @@ mod diesel {
         }
     }
 }
+
+mod local_path_false_negative {
+    use bar::Baz;
+
+    fn foo() -> Baz {
+        bar::Baz::new()
+    }
+
+    mod bar {
+        pub struct Baz;
+
+        impl Baz {
+            pub fn new() -> Self {
+                Self
+            }
+        }
+    }
+}
+
+mod trait_path {
+    use std::borrow::Borrow;
+
+    fn foo<T>(x: &impl Borrow<T>) -> &T {
+        <_ as std::borrow::Borrow<T>>::borrow(x)
+    }
+}
+
+mod relative_module_path {
+    #[allow(unused_imports)]
+    use bar::baz;
+
+    fn foo() {
+        bar::baz::qux()
+    }
+
+    mod bar {
+        pub mod baz {
+            pub fn qux() {}
+        }
+    }
+}

--- a/examples/restriction/inconsistent_qualification/ui/main.stderr
+++ b/examples/restriction/inconsistent_qualification/ui/main.stderr
@@ -59,5 +59,41 @@ note: items from `std::env` were imported here
 LL |         use std::env::var_os;
    |         ^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: inconsistent qualification
+  --> $DIR/main.rs:80:9
+   |
+LL |         bar::Baz::new()
+   |         ^^^^^^^^
+   |
+note: `bar::Baz` was imported here
+  --> $DIR/main.rs:77:5
+   |
+LL |     use bar::Baz;
+   |     ^^^^^^^^^^^^^
+
+error: inconsistent qualification
+  --> $DIR/main.rs:98:15
+   |
+LL |         <_ as std::borrow::Borrow<T>>::borrow(x)
+   |               ^^^^^^^^^^^^^^^^^^^
+   |
+note: `std::borrow::Borrow` was imported here
+  --> $DIR/main.rs:95:5
+   |
+LL |     use std::borrow::Borrow;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: inconsistent qualification
+  --> $DIR/main.rs:107:9
+   |
+LL |         bar::baz::qux()
+   |         ^^^^^^^^
+   |
+note: `bar::baz` was imported here
+  --> $DIR/main.rs:104:5
+   |
+LL |     use bar::baz;
+   |     ^^^^^^^^^^^^^
+
+error: aborting due to 8 previous errors
 

--- a/internal/src/cargo.rs
+++ b/internal/src/cargo.rs
@@ -41,7 +41,7 @@ pub fn update(description: &str, quiet: bool) -> crate::Command {
 
 fn cargo(subcommand: &str, verb: &str, description: &str, quiet: bool) -> crate::Command {
     if !quiet {
-        // smoelius: Writing directly to `stderr` avoids capture by `libtest`.
+        // smoelius: Writing directly to `stderr` prevents capture by `libtest`.
         let message = format!("{verb} {description}");
         std::io::stderr()
             .write_fmt(format_args!(

--- a/utils/testing/src/lib.rs
+++ b/utils/testing/src/lib.rs
@@ -129,7 +129,6 @@ use std::{
 };
 
 pub mod ui;
-use ui::Config;
 
 static DRIVER: OnceCell<PathBuf> = OnceCell::new();
 static LINKING_FLAGS: OnceCell<Vec<String>> = OnceCell::new();
@@ -224,7 +223,7 @@ fn run_example_test(
     metadata: &Metadata,
     package: &Package,
     target: &Target,
-    config: &Config,
+    config: &ui::Config,
 ) -> Result<()> {
     let linking_flags = linking_flags(metadata, package, target)?;
     let file_name = target
@@ -406,7 +405,7 @@ fn copy_with_extension<P: AsRef<Path>, Q: AsRef<Path>>(
 
 static MUTEX: Mutex<()> = Mutex::new(());
 
-fn run_tests(driver: &Path, src_base: &Path, config: &Config) {
+fn run_tests(driver: &Path, src_base: &Path, config: &ui::Config) {
     let _lock = MUTEX.lock().unwrap();
 
     // smoelius: There doesn't seem to be a way to set environment variables using `compiletest`'s


### PR DESCRIPTION
This PR fixes a false negative concerning use of local paths in `inconsistent_qualification`.

It also improves the generated error messages, particularly in regard to traits and modules.