### PR TITLE
Don't markdown-link-check OpenAI urls

### DIFF
--- a/cargo-dylint/tests/markdown_link_check.json
+++ b/cargo-dylint/tests/markdown_link_check.json
@@ -1,5 +1,10 @@
 {
   "httpHeaders": [
     { "urls": ["https://crates.io"], "headers": { "Accept": "text/html" } }
+  ],
+  "ignorePatterns": [
+    {
+      "pattern": "^https://platform.openai.com/"
+    }
   ]
 }


### PR DESCRIPTION
They recently started returning 403s.