### PR TITLE
Unpin `markdown-link-check`

### DIFF
--- a/cargo-dylint/tests/dylint.rs
+++ b/cargo-dylint/tests/dylint.rs
@@ -239,10 +239,8 @@ fn markdown_reference_links_are_valid_and_used() {
 fn markdown_link_check() {
     let tempdir = tempdir().unwrap();
 
-    // smoelius: Pin `markdown-link-check` to version 3.10.3 until the following issue is resolved:
-    // https://github.com/tcort/markdown-link-check/issues/246
     Command::new("npm")
-        .args(["install", "markdown-link-check@3.10.3"])
+        .args(["install", "markdown-link-check"])
         .current_dir(&tempdir)
         .assert()
         .success();


### PR DESCRIPTION
https://github.com/tcort/markdown-link-check/releases/tag/v3.11.2