### PR TITLE
Allow `clippy_utils` to be a workspace dependency

### DIFF
--- a/dylint/src/lib.rs
+++ b/dylint/src/lib.rs
@@ -606,7 +606,18 @@ mod test {
             metadata.target_directory.join("straggler/debug"),
         ])
         .unwrap();
+
+        #[rustfmt::skip]
+        // smoelius: Following the upgrade nightly-2023-08-24, I started seeing the following error:
+        //
+        //   error: internal compiler error: encountered incremental compilation error with shallow_lint_levels_on(dylint_internal[...]::cargo::{use#15})
+        //     |
+        //     = help: This is a known issue with the compiler. Run `cargo clean -p dylint_internal` or `cargo clean` to allow your project to compile
+        //     = note: Please follow the instructions below to create a bug report with the provided information
+        //     = note: See <https://github.com/rust-lang/rust/issues/84970> for more information
+        set_var(env::CARGO_INCREMENTAL, "0");
         set_var(env::DYLINT_LIBRARY_PATH, dylint_library_path);
+
         NameToolchainMap::new(&OPTS)
     }
 

--- a/dylint/src/lib.rs
+++ b/dylint/src/lib.rs
@@ -266,7 +266,7 @@ fn resolve(opts: &Dylint, name_toolchain_map: &NameToolchainMap) -> Result<Toolc
                     .collect::<Result<Vec<_>>>()?;
                 toolchain_map
                     .entry(toolchain.clone())
-                    .or_insert_with(Default::default)
+                    .or_default()
                     .extend(paths);
             }
         }
@@ -277,18 +277,12 @@ fn resolve(opts: &Dylint, name_toolchain_map: &NameToolchainMap) -> Result<Toolc
         let (toolchain, maybe_library) =
             name_as_lib(name_toolchain_map, name, true)?.unwrap_or_else(|| unreachable!());
         let path = maybe_library.build(opts)?;
-        toolchain_map
-            .entry(toolchain)
-            .or_insert_with(Default::default)
-            .insert(path);
+        toolchain_map.entry(toolchain).or_default().insert(path);
     }
 
     for name in &opts.paths {
         let (toolchain, path) = name_as_path(name, true)?.unwrap_or_else(|| unreachable!());
-        toolchain_map
-            .entry(toolchain)
-            .or_insert_with(Default::default)
-            .insert(path);
+        toolchain_map.entry(toolchain).or_default().insert(path);
     }
 
     let mut not_found = Vec::new();
@@ -303,20 +297,15 @@ fn resolve(opts: &Dylint, name_toolchain_map: &NameToolchainMap) -> Result<Toolc
                 name
             );
             let path = maybe_library.build(opts)?;
-            toolchain_map
-                .entry(toolchain)
-                .or_insert_with(Default::default)
-                .insert(path);
+            toolchain_map.entry(toolchain).or_default().insert(path);
         } else if let Some((toolchain, path)) = name_as_path(name, false)? {
-            toolchain_map
-                .entry(toolchain)
-                .or_insert_with(Default::default)
-                .insert(path);
+            toolchain_map.entry(toolchain).or_default().insert(path);
         } else {
             not_found.push(name);
         }
     }
 
+    #[allow(clippy::format_collect)]
     if !not_found.is_empty() {
         not_found.sort_unstable();
         bail!(

--- a/dylint/src/metadata.rs
+++ b/dylint/src/metadata.rs
@@ -281,6 +281,7 @@ fn dependency(
     library: &Library,
 ) -> Result<Dependency> {
     let mut unused_keys = library.details.unused_keys();
+    #[allow(clippy::format_collect)]
     if !unused_keys.is_empty() {
         unused_keys.sort_unstable();
         bail!(

--- a/dylint/src/name_toolchain_map/mod.rs
+++ b/dylint/src/name_toolchain_map/mod.rs
@@ -57,9 +57,9 @@ impl<'opts> Lazy<'opts> {
                         let (name, toolchain, path) = entry?;
                         name_toolchain_map
                             .entry(name)
-                            .or_insert_with(Default::default)
+                            .or_default()
                             .entry(toolchain)
-                            .or_insert_with(Default::default)
+                            .or_default()
                             .insert(MaybeLibrary::from(path));
                     }
                 }
@@ -68,9 +68,9 @@ impl<'opts> Lazy<'opts> {
                 for package in workspace_metadata_packages {
                     name_toolchain_map
                         .entry(package.lib_name.clone())
-                        .or_insert_with(Default::default)
+                        .or_default()
                         .entry(package.toolchain.clone())
-                        .or_insert_with(Default::default)
+                        .or_default()
                         .insert(MaybeLibrary::from(package));
                 }
 

--- a/examples/general/Cargo.lock
+++ b/examples/general/Cargo.lock
@@ -145,8 +145,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.73"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=1d334696587ac22b3a9e651e7ac684ac9e0697b2#1d334696587ac22b3a9e651e7ac684ac9e0697b2"
+version = "0.1.74"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/general/Cargo.lock
+++ b/examples/general/Cargo.lock
@@ -146,7 +146,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "clippy_utils"
 version = "0.1.74"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=acdffd791b31d96cdeb15368132e8ca91f2089af#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/general/Cargo.toml
+++ b/examples/general/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 ]
 
 [workspace.dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
 
 [workspace.metadata.dylint]
 libraries = [

--- a/examples/general/Cargo.toml
+++ b/examples/general/Cargo.toml
@@ -30,6 +30,9 @@ members = [
     "non_thread_safe_call_in_test",
 ]
 
+[workspace.dependencies]
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+
 [workspace.metadata.dylint]
 libraries = [
     { path = "../general" },

--- a/examples/general/Cargo.toml
+++ b/examples/general/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 ]
 
 [workspace.dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "acdffd791b31d96cdeb15368132e8ca91f2089af" }
 
 [workspace.metadata.dylint]
 libraries = [

--- a/examples/general/await_holding_span_guard/Cargo.toml
+++ b/examples/general/await_holding_span_guard/Cargo.toml
@@ -14,7 +14,7 @@ name = "ui"
 path = "ui/main.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { workspace = true }
 
 dylint_linting = { path = "../../../utils/linting" }
 

--- a/examples/general/crate_wide_allow/Cargo.toml
+++ b/examples/general/crate_wide_allow/Cargo.toml
@@ -14,7 +14,7 @@ name = "ui"
 path = "ui/main.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { workspace = true }
 if_chain = "1.0"
 
 dylint_linting = { path = "../../../utils/linting" }

--- a/examples/general/env_cargo_path/Cargo.toml
+++ b/examples/general/env_cargo_path/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { workspace = true }
 if_chain = "1.0"
 
 dylint_linting = { path = "../../../utils/linting" }

--- a/examples/general/env_cargo_path/src/lib.rs
+++ b/examples/general/env_cargo_path/src/lib.rs
@@ -68,13 +68,8 @@ impl EarlyLintPass for EnvCargoPath {
             if !self.in_test_item();
             if let ExprKind::MacCall(mac) = &expr.kind;
             if mac.path == sym!(env) || mac.path == sym!(option_env);
-            if let [TokenTree::Token(token, _)] = mac
-                .args
-                .tokens
-                .clone()
-                .into_trees()
-                .collect::<Vec<_>>()
-                .as_slice();
+            if let [TokenTree::Token(token, _)] =
+                mac.args.tokens.trees().collect::<Vec<_>>().as_slice();
             if let TokenKind::Literal(lit) = token.kind;
             if lit.kind == LitKind::Str;
             if is_blacklisted_variable(lit.symbol.as_str());

--- a/examples/general/non_local_effect_before_error_return/Cargo.toml
+++ b/examples/general/non_local_effect_before_error_return/Cargo.toml
@@ -14,7 +14,7 @@ name = "ui"
 path = "ui/main.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { workspace = true }
 if_chain = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 

--- a/examples/general/non_local_effect_before_error_return/src/visit_error_paths.rs
+++ b/examples/general/non_local_effect_before_error_return/src/visit_error_paths.rs
@@ -288,7 +288,7 @@ fn is_from_residual_or_try_implementor_method_call<'tcx>(
         if let Some((def_id, _)) = func.const_fn_def();
         if let [arg, ..] = args.as_slice();
         if let Some(arg_place) = arg.place();
-        let _ = if Some(def_id) == cx.tcx.lang_items().from_residual_fn() {
+        let () = if Some(def_id) == cx.tcx.lang_items().from_residual_fn() {
             return Some(arg_place);
         };
         if let Some(assoc_item) = cx.tcx.opt_associated_item(def_id);

--- a/examples/general/non_thread_safe_call_in_test/Cargo.toml
+++ b/examples/general/non_thread_safe_call_in_test/Cargo.toml
@@ -22,7 +22,7 @@ name = "set_current_dir"
 path = "ui_late/set_current_dir.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { workspace = true }
 if_chain = "1.0"
 
 dylint_internal = { path = "../../../internal" }

--- a/examples/general/non_thread_safe_call_in_test/src/late.rs
+++ b/examples/general/non_thread_safe_call_in_test/src/late.rs
@@ -91,7 +91,7 @@ impl NonThreadSafeCallInTest {
             // smoelius:
             // https://rustc-dev-guide.rust-lang.org/test-implementation.html?highlight=testdesc#step-3-test-object-generation
             if_chain! {
-                if let ItemKind::Const(ty, const_body_id) = item.kind;
+                if let ItemKind::Const(ty, _, const_body_id) = item.kind;
                 if let Some(ty_def_id) = path_def_id(cx, ty);
                 if match_def_path(cx, ty_def_id, &paths::TEST_DESC_AND_FN);
                 let const_body = cx.tcx.hir().body(const_body_id);

--- a/examples/general/rust-toolchain
+++ b/examples/general/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-07-14"
+channel = "nightly-2023-08-24"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/examples/restriction/assert_eq_arg_misordering/Cargo.lock
+++ b/examples/restriction/assert_eq_arg_misordering/Cargo.lock
@@ -123,8 +123,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.73"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=1d334696587ac22b3a9e651e7ac684ac9e0697b2#1d334696587ac22b3a9e651e7ac684ac9e0697b2"
+version = "0.1.74"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/assert_eq_arg_misordering/Cargo.lock
+++ b/examples/restriction/assert_eq_arg_misordering/Cargo.lock
@@ -124,7 +124,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "clippy_utils"
 version = "0.1.74"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=acdffd791b31d96cdeb15368132e8ca91f2089af#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/assert_eq_arg_misordering/Cargo.toml
+++ b/examples/restriction/assert_eq_arg_misordering/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "acdffd791b31d96cdeb15368132e8ca91f2089af" }
 if_chain = "1.0"
 
 dylint_linting = { path = "../../../utils/linting" }

--- a/examples/restriction/assert_eq_arg_misordering/Cargo.toml
+++ b/examples/restriction/assert_eq_arg_misordering/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
 if_chain = "1.0"
 
 dylint_linting = { path = "../../../utils/linting" }

--- a/examples/restriction/assert_eq_arg_misordering/rust-toolchain
+++ b/examples/restriction/assert_eq_arg_misordering/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-07-14"
+channel = "nightly-2023-08-24"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/examples/restriction/collapsible_unwrap/Cargo.lock
+++ b/examples/restriction/collapsible_unwrap/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "clippy_utils"
 version = "0.1.74"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=acdffd791b31d96cdeb15368132e8ca91f2089af#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/collapsible_unwrap/Cargo.lock
+++ b/examples/restriction/collapsible_unwrap/Cargo.lock
@@ -113,8 +113,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.73"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=1d334696587ac22b3a9e651e7ac684ac9e0697b2#1d334696587ac22b3a9e651e7ac684ac9e0697b2"
+version = "0.1.74"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/collapsible_unwrap/Cargo.toml
+++ b/examples/restriction/collapsible_unwrap/Cargo.toml
@@ -14,7 +14,7 @@ name = "ui"
 path = "ui/main.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "acdffd791b31d96cdeb15368132e8ca91f2089af" }
 heck = "0.4"
 if_chain = "1.0"
 

--- a/examples/restriction/collapsible_unwrap/Cargo.toml
+++ b/examples/restriction/collapsible_unwrap/Cargo.toml
@@ -14,7 +14,7 @@ name = "ui"
 path = "ui/main.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
 heck = "0.4"
 if_chain = "1.0"
 

--- a/examples/restriction/collapsible_unwrap/rust-toolchain
+++ b/examples/restriction/collapsible_unwrap/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-07-14"
+channel = "nightly-2023-08-24"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/examples/restriction/const_path_join/Cargo.lock
+++ b/examples/restriction/const_path_join/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "clippy_utils"
 version = "0.1.74"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=acdffd791b31d96cdeb15368132e8ca91f2089af#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/const_path_join/Cargo.lock
+++ b/examples/restriction/const_path_join/Cargo.lock
@@ -113,8 +113,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.73"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=1d334696587ac22b3a9e651e7ac684ac9e0697b2#1d334696587ac22b3a9e651e7ac684ac9e0697b2"
+version = "0.1.74"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/const_path_join/Cargo.toml
+++ b/examples/restriction/const_path_join/Cargo.toml
@@ -14,7 +14,7 @@ name = "ui"
 path = "ui/main.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "acdffd791b31d96cdeb15368132e8ca91f2089af" }
 if_chain = "1.0"
 
 dylint_internal = { path = "../../../internal" }

--- a/examples/restriction/const_path_join/Cargo.toml
+++ b/examples/restriction/const_path_join/Cargo.toml
@@ -14,7 +14,7 @@ name = "ui"
 path = "ui/main.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
 if_chain = "1.0"
 
 dylint_internal = { path = "../../../internal" }

--- a/examples/restriction/const_path_join/rust-toolchain
+++ b/examples/restriction/const_path_join/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-07-14"
+channel = "nightly-2023-08-24"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/examples/restriction/derive_opportunity/Cargo.lock
+++ b/examples/restriction/derive_opportunity/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "clippy_utils"
 version = "0.1.74"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=acdffd791b31d96cdeb15368132e8ca91f2089af#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/derive_opportunity/Cargo.lock
+++ b/examples/restriction/derive_opportunity/Cargo.lock
@@ -113,8 +113,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.73"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=1d334696587ac22b3a9e651e7ac684ac9e0697b2#1d334696587ac22b3a9e651e7ac684ac9e0697b2"
+version = "0.1.74"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/derive_opportunity/Cargo.toml
+++ b/examples/restriction/derive_opportunity/Cargo.toml
@@ -22,7 +22,7 @@ name = "ui_ignore"
 path = "ui_ignore/main.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "acdffd791b31d96cdeb15368132e8ca91f2089af" }
 if_chain = "1.0"
 once_cell = "1.18"
 serde = "1.0"

--- a/examples/restriction/derive_opportunity/Cargo.toml
+++ b/examples/restriction/derive_opportunity/Cargo.toml
@@ -22,7 +22,7 @@ name = "ui_ignore"
 path = "ui_ignore/main.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
 if_chain = "1.0"
 once_cell = "1.18"
 serde = "1.0"

--- a/examples/restriction/derive_opportunity/rust-toolchain
+++ b/examples/restriction/derive_opportunity/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-07-14"
+channel = "nightly-2023-08-24"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/examples/restriction/env_literal/Cargo.lock
+++ b/examples/restriction/env_literal/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "clippy_utils"
 version = "0.1.74"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=acdffd791b31d96cdeb15368132e8ca91f2089af#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/env_literal/Cargo.lock
+++ b/examples/restriction/env_literal/Cargo.lock
@@ -113,8 +113,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.73"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=1d334696587ac22b3a9e651e7ac684ac9e0697b2#1d334696587ac22b3a9e651e7ac684ac9e0697b2"
+version = "0.1.74"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/env_literal/Cargo.toml
+++ b/examples/restriction/env_literal/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "acdffd791b31d96cdeb15368132e8ca91f2089af" }
 if_chain = "1.0"
 
 dylint_internal = { path = "../../../internal" }

--- a/examples/restriction/env_literal/Cargo.toml
+++ b/examples/restriction/env_literal/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
 if_chain = "1.0"
 
 dylint_internal = { path = "../../../internal" }

--- a/examples/restriction/env_literal/rust-toolchain
+++ b/examples/restriction/env_literal/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-07-14"
+channel = "nightly-2023-08-24"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/examples/restriction/inconsistent_qualification/Cargo.lock
+++ b/examples/restriction/inconsistent_qualification/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "clippy_utils"
 version = "0.1.74"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=acdffd791b31d96cdeb15368132e8ca91f2089af#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/inconsistent_qualification/Cargo.lock
+++ b/examples/restriction/inconsistent_qualification/Cargo.lock
@@ -113,8 +113,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.73"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=1d334696587ac22b3a9e651e7ac684ac9e0697b2#1d334696587ac22b3a9e651e7ac684ac9e0697b2"
+version = "0.1.74"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/inconsistent_qualification/Cargo.toml
+++ b/examples/restriction/inconsistent_qualification/Cargo.toml
@@ -14,7 +14,7 @@ name = "ui"
 path = "ui/main.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
 if_chain = "1.0"
 
 dylint_linting = { path = "../../../utils/linting" }

--- a/examples/restriction/inconsistent_qualification/Cargo.toml
+++ b/examples/restriction/inconsistent_qualification/Cargo.toml
@@ -14,7 +14,7 @@ name = "ui"
 path = "ui/main.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "acdffd791b31d96cdeb15368132e8ca91f2089af" }
 if_chain = "1.0"
 
 dylint_linting = { path = "../../../utils/linting" }

--- a/examples/restriction/inconsistent_qualification/rust-toolchain
+++ b/examples/restriction/inconsistent_qualification/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-07-14"
+channel = "nightly-2023-08-24"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/examples/restriction/misleading_variable_name/Cargo.lock
+++ b/examples/restriction/misleading_variable_name/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "clippy_utils"
 version = "0.1.74"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=acdffd791b31d96cdeb15368132e8ca91f2089af#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/misleading_variable_name/Cargo.lock
+++ b/examples/restriction/misleading_variable_name/Cargo.lock
@@ -113,8 +113,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.73"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=1d334696587ac22b3a9e651e7ac684ac9e0697b2#1d334696587ac22b3a9e651e7ac684ac9e0697b2"
+version = "0.1.74"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/misleading_variable_name/Cargo.toml
+++ b/examples/restriction/misleading_variable_name/Cargo.toml
@@ -14,7 +14,7 @@ name = "ui"
 path = "ui/main.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "acdffd791b31d96cdeb15368132e8ca91f2089af" }
 heck = "0.4"
 if_chain = "1.0"
 

--- a/examples/restriction/misleading_variable_name/Cargo.toml
+++ b/examples/restriction/misleading_variable_name/Cargo.toml
@@ -14,7 +14,7 @@ name = "ui"
 path = "ui/main.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
 heck = "0.4"
 if_chain = "1.0"
 

--- a/examples/restriction/misleading_variable_name/rust-toolchain
+++ b/examples/restriction/misleading_variable_name/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-07-14"
+channel = "nightly-2023-08-24"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/examples/restriction/missing_doc_comment_openai/Cargo.lock
+++ b/examples/restriction/missing_doc_comment_openai/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "clippy_utils"
 version = "0.1.74"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=acdffd791b31d96cdeb15368132e8ca91f2089af#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/missing_doc_comment_openai/Cargo.lock
+++ b/examples/restriction/missing_doc_comment_openai/Cargo.lock
@@ -113,8 +113,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.73"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=1d334696587ac22b3a9e651e7ac684ac9e0697b2#1d334696587ac22b3a9e651e7ac684ac9e0697b2"
+version = "0.1.74"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/missing_doc_comment_openai/Cargo.toml
+++ b/examples/restriction/missing_doc_comment_openai/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "acdffd791b31d96cdeb15368132e8ca91f2089af" }
 curl = "0.4"
 serde = "1.0"
 serde_json = "1.0"

--- a/examples/restriction/missing_doc_comment_openai/Cargo.toml
+++ b/examples/restriction/missing_doc_comment_openai/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
 curl = "0.4"
 serde = "1.0"
 serde_json = "1.0"

--- a/examples/restriction/missing_doc_comment_openai/rust-toolchain
+++ b/examples/restriction/missing_doc_comment_openai/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-07-14"
+channel = "nightly-2023-08-24"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/examples/restriction/overscoped_allow/Cargo.lock
+++ b/examples/restriction/overscoped_allow/Cargo.lock
@@ -136,7 +136,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "clippy_utils"
 version = "0.1.74"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=acdffd791b31d96cdeb15368132e8ca91f2089af#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/overscoped_allow/Cargo.lock
+++ b/examples/restriction/overscoped_allow/Cargo.lock
@@ -135,8 +135,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.73"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=1d334696587ac22b3a9e651e7ac684ac9e0697b2#1d334696587ac22b3a9e651e7ac684ac9e0697b2"
+version = "0.1.74"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/overscoped_allow/Cargo.toml
+++ b/examples/restriction/overscoped_allow/Cargo.toml
@@ -19,7 +19,7 @@ path = "ui_test/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
 if_chain = "1.0"
 rustfix = "0.6"
 serde = "1.0"

--- a/examples/restriction/overscoped_allow/Cargo.toml
+++ b/examples/restriction/overscoped_allow/Cargo.toml
@@ -19,7 +19,7 @@ path = "ui_test/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "acdffd791b31d96cdeb15368132e8ca91f2089af" }
 if_chain = "1.0"
 rustfix = "0.6"
 serde = "1.0"

--- a/examples/restriction/overscoped_allow/rust-toolchain
+++ b/examples/restriction/overscoped_allow/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2023-07-14"
+channel = "nightly-2023-08-24"
 # smoelius: The ui tests require `clippy`.
 components = ["clippy", "llvm-tools-preview", "rustc-dev"]

--- a/examples/restriction/question_mark_in_expression/Cargo.lock
+++ b/examples/restriction/question_mark_in_expression/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "clippy_utils"
 version = "0.1.74"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=acdffd791b31d96cdeb15368132e8ca91f2089af#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/question_mark_in_expression/Cargo.lock
+++ b/examples/restriction/question_mark_in_expression/Cargo.lock
@@ -113,8 +113,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.73"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=1d334696587ac22b3a9e651e7ac684ac9e0697b2#1d334696587ac22b3a9e651e7ac684ac9e0697b2"
+version = "0.1.74"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/question_mark_in_expression/Cargo.toml
+++ b/examples/restriction/question_mark_in_expression/Cargo.toml
@@ -26,7 +26,7 @@ name = "non-empty"
 path = "ui/non-empty.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "acdffd791b31d96cdeb15368132e8ca91f2089af" }
 if_chain = "1.0"
 
 dylint_linting = { path = "../../../utils/linting" }

--- a/examples/restriction/question_mark_in_expression/Cargo.toml
+++ b/examples/restriction/question_mark_in_expression/Cargo.toml
@@ -26,7 +26,7 @@ name = "non-empty"
 path = "ui/non-empty.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
 if_chain = "1.0"
 
 dylint_linting = { path = "../../../utils/linting" }

--- a/examples/restriction/question_mark_in_expression/rust-toolchain
+++ b/examples/restriction/question_mark_in_expression/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-07-14"
+channel = "nightly-2023-08-24"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/examples/restriction/question_mark_in_expression/src/lib.rs
+++ b/examples/restriction/question_mark_in_expression/src/lib.rs
@@ -45,7 +45,7 @@ impl<'tcx> LateLintPass<'tcx> for QuestionMarkInExpression {
                 .hir()
                 .parent_iter(expr.hir_id)
                 .any(|(hir_id, _)| cx.tcx.hir().span(hir_id).in_derive_expansion());
-            if let ExprKind::Match(_, _, MatchSource::TryDesugar) = expr.kind;
+            if let ExprKind::Match(_, _, MatchSource::TryDesugar(_)) = expr.kind;
             if let Some((Node::Expr(ancestor), child_hir_id)) =
                 get_filtered_ancestor(cx, expr.hir_id);
             // smoelius: `AssignOp`, `If`, `Let`, and `Match` expressions get a pass.

--- a/examples/restriction/ref_aware_redundant_closure_for_method_calls/Cargo.lock
+++ b/examples/restriction/ref_aware_redundant_closure_for_method_calls/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "clippy_utils"
 version = "0.1.74"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=acdffd791b31d96cdeb15368132e8ca91f2089af#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/ref_aware_redundant_closure_for_method_calls/Cargo.lock
+++ b/examples/restriction/ref_aware_redundant_closure_for_method_calls/Cargo.lock
@@ -113,8 +113,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.73"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=1d334696587ac22b3a9e651e7ac684ac9e0697b2#1d334696587ac22b3a9e651e7ac684ac9e0697b2"
+version = "0.1.74"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/ref_aware_redundant_closure_for_method_calls/Cargo.toml
+++ b/examples/restriction/ref_aware_redundant_closure_for_method_calls/Cargo.toml
@@ -18,7 +18,7 @@ name = "ref_aware"
 path = "ui/ref_aware.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
 if_chain = "1.0"
 
 dylint_internal = { path = "../../../internal" }

--- a/examples/restriction/ref_aware_redundant_closure_for_method_calls/Cargo.toml
+++ b/examples/restriction/ref_aware_redundant_closure_for_method_calls/Cargo.toml
@@ -18,7 +18,7 @@ name = "ref_aware"
 path = "ui/ref_aware.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "acdffd791b31d96cdeb15368132e8ca91f2089af" }
 if_chain = "1.0"
 
 dylint_internal = { path = "../../../internal" }

--- a/examples/restriction/ref_aware_redundant_closure_for_method_calls/rust-toolchain
+++ b/examples/restriction/ref_aware_redundant_closure_for_method_calls/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-07-14"
+channel = "nightly-2023-08-24"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/examples/restriction/ref_aware_redundant_closure_for_method_calls/src/lib.rs
+++ b/examples/restriction/ref_aware_redundant_closure_for_method_calls/src/lib.rs
@@ -25,7 +25,7 @@ use rustc_hir::{Closure, Expr, ExprKind, Param, PatKind, Unsafety};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::adjustment::{Adjust, Adjustment, AutoBorrow};
 use rustc_middle::ty::binding::BindingMode;
-use rustc_middle::ty::{self, EarlyBinder, SubstsRef, Ty, TypeVisitable, TypeVisitableExt};
+use rustc_middle::ty::{self, EarlyBinder, GenericArgsRef, Ty, TypeVisitable, TypeVisitableExt};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::symbol::sym;
 
@@ -148,8 +148,8 @@ impl<'tcx> LateLintPass<'tcx> for RefAwareRedundantClosureForMethodCalls {
             let parent_receiver_ty = cx.typeck_results().expr_ty(parent_receiver);
             if is_type_diagnostic_item(cx, parent_receiver_ty, sym::Option);
             let method_def_id = cx.typeck_results().type_dependent_def_id(body.value.hir_id).unwrap();
-            let substs = cx.typeck_results().node_substs(body.value.hir_id);
-            let call_ty = cx.tcx.type_of(method_def_id).subst(cx.tcx, substs);
+            let generic_args = cx.typeck_results().node_args(body.value.hir_id);
+            let call_ty = cx.tcx.type_of(method_def_id).instantiate(cx.tcx, generic_args);
             if check_sig(cx, closure_ty, call_ty);
             then {
                 let parent_method_call_span = trim_span(
@@ -157,7 +157,7 @@ impl<'tcx> LateLintPass<'tcx> for RefAwareRedundantClosureForMethodCalls {
                     span.with_lo(parent_receiver.span.hi()),
                 );
                 span_lint_and_then(cx, REF_AWARE_REDUNDANT_CLOSURE_FOR_METHOD_CALLS, parent_method_call_span, "redundant closure", |diag| {
-                let name = get_ufcs_type_name(cx, method_def_id, substs);
+                let name = get_ufcs_type_name(cx, method_def_id, generic_args);
                     diag.span_suggestion(
                         parent_method_call_span,
                         "replace the closure with the method itself",
@@ -250,19 +250,19 @@ fn check_sig<'tcx>(cx: &LateContext<'tcx>, closure_ty: Ty<'tcx>, call_ty: Ty<'tc
     if !closure_ty.has_late_bound_regions() {
         return true;
     }
-    let ty::Closure(_, substs) = closure_ty.kind() else {
+    let ty::Closure(_, generic_args) = closure_ty.kind() else {
         return false;
     };
     let closure_sig = cx
         .tcx
-        .signature_unclosure(substs.as_closure().sig(), Unsafety::Normal);
+        .signature_unclosure(generic_args.as_closure().sig(), Unsafety::Normal);
     cx.tcx.erase_late_bound_regions(closure_sig) == cx.tcx.erase_late_bound_regions(call_sig)
 }
 
 fn get_ufcs_type_name<'tcx>(
     cx: &LateContext<'tcx>,
     method_def_id: DefId,
-    substs: SubstsRef<'tcx>,
+    generic_args: GenericArgsRef<'tcx>,
 ) -> String {
     let assoc_item = cx.tcx.associated_item(method_def_id);
     let def_id = assoc_item.container_id(cx.tcx);
@@ -279,7 +279,10 @@ fn get_ufcs_type_name<'tcx>(
                 | ty::Ref(..)
                 | ty::Slice(_)
                 | ty::Tuple(_) => {
-                    format!("<{}>", EarlyBinder::bind(ty).subst(cx.tcx, substs))
+                    format!(
+                        "<{}>",
+                        EarlyBinder::bind(ty).instantiate(cx.tcx, generic_args)
+                    )
                 }
                 _ => ty.to_string(),
             }

--- a/examples/restriction/suboptimal_pattern/Cargo.lock
+++ b/examples/restriction/suboptimal_pattern/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "clippy_utils"
 version = "0.1.74"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=acdffd791b31d96cdeb15368132e8ca91f2089af#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/suboptimal_pattern/Cargo.lock
+++ b/examples/restriction/suboptimal_pattern/Cargo.lock
@@ -113,8 +113,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.73"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=1d334696587ac22b3a9e651e7ac684ac9e0697b2#1d334696587ac22b3a9e651e7ac684ac9e0697b2"
+version = "0.1.74"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/suboptimal_pattern/Cargo.toml
+++ b/examples/restriction/suboptimal_pattern/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
 if_chain = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 

--- a/examples/restriction/suboptimal_pattern/Cargo.toml
+++ b/examples/restriction/suboptimal_pattern/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "acdffd791b31d96cdeb15368132e8ca91f2089af" }
 if_chain = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 

--- a/examples/restriction/suboptimal_pattern/rust-toolchain
+++ b/examples/restriction/suboptimal_pattern/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-07-14"
+channel = "nightly-2023-08-24"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/examples/restriction/try_io_result/Cargo.lock
+++ b/examples/restriction/try_io_result/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "clippy_utils"
 version = "0.1.74"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=acdffd791b31d96cdeb15368132e8ca91f2089af#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/try_io_result/Cargo.lock
+++ b/examples/restriction/try_io_result/Cargo.lock
@@ -113,8 +113,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.73"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=1d334696587ac22b3a9e651e7ac684ac9e0697b2#1d334696587ac22b3a9e651e7ac684ac9e0697b2"
+version = "0.1.74"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/restriction/try_io_result/Cargo.toml
+++ b/examples/restriction/try_io_result/Cargo.toml
@@ -14,7 +14,7 @@ name = "ui"
 path = "ui/main.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "acdffd791b31d96cdeb15368132e8ca91f2089af" }
 if_chain = "1.0"
 
 dylint_internal = { path = "../../../internal" }

--- a/examples/restriction/try_io_result/Cargo.toml
+++ b/examples/restriction/try_io_result/Cargo.toml
@@ -14,7 +14,7 @@ name = "ui"
 path = "ui/main.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
 if_chain = "1.0"
 
 dylint_internal = { path = "../../../internal" }

--- a/examples/restriction/try_io_result/rust-toolchain
+++ b/examples/restriction/try_io_result/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-07-14"
+channel = "nightly-2023-08-24"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/examples/restriction/try_io_result/src/lib.rs
+++ b/examples/restriction/try_io_result/src/lib.rs
@@ -10,7 +10,7 @@ use clippy_utils::{diagnostics::span_lint_and_help, match_def_path};
 use if_chain::if_chain;
 use rustc_hir::{Expr, ExprKind, LangItem, MatchSource, QPath};
 use rustc_lint::{LateContext, LateLintPass};
-use rustc_middle::ty::{subst::GenericArgKind, Ty, TyKind};
+use rustc_middle::ty::{GenericArgKind, Ty, TyKind};
 use rustc_span::sym;
 
 dylint_linting::declare_late_lint! {
@@ -53,7 +53,7 @@ dylint_linting::declare_late_lint! {
 impl<'tcx> LateLintPass<'tcx> for TryIoResult {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
         if_chain! {
-            if let ExprKind::Match(scrutinee, _, MatchSource::TryDesugar) = expr.kind;
+            if let ExprKind::Match(scrutinee, _, MatchSource::TryDesugar(_)) = expr.kind;
             if let ExprKind::Call(callee, [arg]) = scrutinee.kind;
             if let ExprKind::Path(path) = &callee.kind;
             if matches!(path, QPath::LangItem(LangItem::TryTraitBranch, _, _));

--- a/examples/supplementary/Cargo.lock
+++ b/examples/supplementary/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "clippy_utils"
 version = "0.1.74"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=acdffd791b31d96cdeb15368132e8ca91f2089af#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/supplementary/Cargo.lock
+++ b/examples/supplementary/Cargo.lock
@@ -113,8 +113,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.73"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=1d334696587ac22b3a9e651e7ac684ac9e0697b2#1d334696587ac22b3a9e651e7ac684ac9e0697b2"
+version = "0.1.74"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/supplementary/Cargo.toml
+++ b/examples/supplementary/Cargo.toml
@@ -30,6 +30,9 @@ members = [
     "unnecessary_conversion_for_trait",
 ]
 
+[workspace.dependencies]
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+
 [workspace.metadata.dylint]
 libraries = [
     { path = "../general" },

--- a/examples/supplementary/Cargo.toml
+++ b/examples/supplementary/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 ]
 
 [workspace.dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
 
 [workspace.metadata.dylint]
 libraries = [

--- a/examples/supplementary/Cargo.toml
+++ b/examples/supplementary/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 ]
 
 [workspace.dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "acdffd791b31d96cdeb15368132e8ca91f2089af" }
 
 [workspace.metadata.dylint]
 libraries = [

--- a/examples/supplementary/commented_code/Cargo.toml
+++ b/examples/supplementary/commented_code/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { workspace = true }
 if_chain = "1.0"
 once_cell = "1.18"
 regex = "1.9"

--- a/examples/supplementary/redundant_reference/Cargo.toml
+++ b/examples/supplementary/redundant_reference/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { workspace = true }
 if_chain = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 

--- a/examples/supplementary/redundant_reference/src/lib.rs
+++ b/examples/supplementary/redundant_reference/src/lib.rs
@@ -134,10 +134,7 @@ impl<'tcx> LateLintPass<'tcx> for RedundantReference {
             let parent_ty = cx.typeck_results().expr_ty(parent);
             if is_copy(cx, parent_ty);
             then {
-                let field_use = self
-                    .field_uses
-                    .entry((local_def_id, field))
-                    .or_insert_with(Default::default);
+                let field_use = self.field_uses.entry((local_def_id, field)).or_default();
                 if let ExprKind::Field(_, subfield) = parent.kind {
                     let subfield_access = field_use
                         .subfield_accesses

--- a/examples/supplementary/rust-toolchain
+++ b/examples/supplementary/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-07-14"
+channel = "nightly-2023-08-24"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/examples/supplementary/unnamed_constant/Cargo.toml
+++ b/examples/supplementary/unnamed_constant/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { workspace = true }
 if_chain = "1.0"
 serde = "1.0"
 

--- a/examples/supplementary/unnecessary_borrow_mut/Cargo.toml
+++ b/examples/supplementary/unnecessary_borrow_mut/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { workspace = true }
 if_chain = "1.0"
 
 dylint_internal = { path = "../../../internal" }

--- a/examples/supplementary/unnecessary_borrow_mut/src/lib.rs
+++ b/examples/supplementary/unnecessary_borrow_mut/src/lib.rs
@@ -170,7 +170,7 @@ impl<'tcx> Visitor<'tcx> for V<'tcx> {
                 destination,
                 ..
             } = &terminator.kind;
-            let _ = if destination.as_local() == Some(self.local) {
+            let () = if destination.as_local() == Some(self.local) {
                 return;
             };
             if let Some((def_id, _)) = func.const_fn_def();

--- a/examples/supplementary/unnecessary_conversion_for_trait/Cargo.toml
+++ b/examples/supplementary/unnecessary_conversion_for_trait/Cargo.toml
@@ -22,7 +22,7 @@ name = "vec"
 path = "ui/vec.rs"
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { workspace = true }
 if_chain = "1.0"
 
 dylint_internal = { path = "../../../internal", features = ["cargo"] }

--- a/examples/supplementary/unnecessary_conversion_for_trait/src/check_inherents.rs
+++ b/examples/supplementary/unnecessary_conversion_for_trait/src/check_inherents.rs
@@ -195,7 +195,7 @@ fn strip_as_ref<'tcx>(
                 if let ty::ClauseKind::Trait(ty::TraitPredicate { trait_ref, .. }) =
                     predicate.kind().skip_binder();
                 if cx.tcx.get_diagnostic_item(sym::AsRef) == Some(trait_ref.def_id);
-                if let [self_arg, subst_arg] = trait_ref.substs.as_slice();
+                if let [self_arg, subst_arg] = trait_ref.args.as_slice();
                 if self_arg.unpack() == ty::GenericArgKind::Type(ty);
                 if let ty::GenericArgKind::Type(subst_ty) = subst_arg.unpack();
                 then {

--- a/examples/supplementary/unnecessary_conversion_for_trait/ui/general.fixed
+++ b/examples/supplementary/unnecessary_conversion_for_trait/ui/general.fixed
@@ -30,7 +30,7 @@ fn main() {
 
     let _ = std::fs::write("x", "");
 
-    let _ = std::fs::write("x", "");
+    let _ = std::fs::write("x", &s);
 
     read(&mut readable);
     read(&mut readable);
@@ -40,7 +40,7 @@ fn main() {
     let _ = std::fs::write("x", "");
     let _ = std::fs::write("x", "");
 
-    let _ = std::fs::write("x", "");
+    let _ = std::fs::write("x", &s);
 
     read(&mut readable);
 
@@ -74,6 +74,7 @@ fn main() {
 
     let _ = std::fs::write(&osstring, "");
     let _ = is_empty_os(osstring.clone());
+    let _ = os_string_or_bytes(osstring.clone());
 
     let _ = std::fs::write(path, "");
     let _ = std::fs::write(PathBuf::from("x"), "");
@@ -108,3 +109,10 @@ trait OsStrOrBytes {}
 impl OsStrOrBytes for &OsStr {}
 impl OsStrOrBytes for &[u8] {}
 fn os_str_or_bytes(_: impl OsStrOrBytes) {}
+
+// smoelius: Similar hack for `OsString` and `Vec<u8>`.
+// Reference: https://github.com/rust-lang/rust/issues/111544
+trait OsStringOrBytes {}
+impl OsStringOrBytes for OsString {}
+impl OsStringOrBytes for Vec<u8> {}
+fn os_string_or_bytes(_: impl OsStringOrBytes) {}

--- a/examples/supplementary/unnecessary_conversion_for_trait/ui/general.rs
+++ b/examples/supplementary/unnecessary_conversion_for_trait/ui/general.rs
@@ -30,7 +30,7 @@ fn main() {
 
     let _ = std::fs::write("x", "".to_string());
 
-    let _ = std::fs::write("x", "".borrow());
+    let _ = std::fs::write("x", <_ as Borrow<str>>::borrow(&s));
 
     read(<_ as BorrowMut<&[u8]>>::borrow_mut(&mut readable));
     read(<_ as BorrowMut<Box<_>>>::borrow_mut(&mut readable));
@@ -40,7 +40,7 @@ fn main() {
     let _ = std::fs::write("x", <_ as AsRef<[u8]>>::as_ref(""));
     let _ = std::fs::write("x", <_ as AsRef<str>>::as_ref(""));
 
-    let _ = std::fs::write("x", "".deref());
+    let _ = std::fs::write("x", s.deref());
 
     read(readable.deref_mut());
 
@@ -74,6 +74,7 @@ fn main() {
 
     let _ = std::fs::write(osstring.as_os_str(), "");
     let _ = is_empty_os(osstring.clone().into_boxed_os_str());
+    let _ = os_string_or_bytes(osstring.clone().into_os_str_bytes());
 
     let _ = std::fs::write(path.as_os_str(), "");
     let _ = std::fs::write(PathBuf::from("x").as_mut_os_str(), "");
@@ -108,3 +109,10 @@ trait OsStrOrBytes {}
 impl OsStrOrBytes for &OsStr {}
 impl OsStrOrBytes for &[u8] {}
 fn os_str_or_bytes(_: impl OsStrOrBytes) {}
+
+// smoelius: Similar hack for `OsString` and `Vec<u8>`.
+// Reference: https://github.com/rust-lang/rust/issues/111544
+trait OsStringOrBytes {}
+impl OsStringOrBytes for OsString {}
+impl OsStringOrBytes for Vec<u8> {}
+fn os_string_or_bytes(_: impl OsStringOrBytes) {}

--- a/examples/supplementary/unnecessary_conversion_for_trait/ui/general.stderr
+++ b/examples/supplementary/unnecessary_conversion_for_trait/ui/general.stderr
@@ -12,11 +12,11 @@ error: the receiver implements the required traits
 LL |     let _ = std::fs::write("x", "".to_string());
    |                                   ^^^^^^^^^^^^ help: remove this
 
-error: the receiver implements the required traits
-  --> $DIR/general.rs:33:35
+error: the inner argument implements the required traits
+  --> $DIR/general.rs:33:33
    |
-LL |     let _ = std::fs::write("x", "".borrow());
-   |                                   ^^^^^^^^^ help: remove this
+LL |     let _ = std::fs::write("x", <_ as Borrow<str>>::borrow(&s));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `&s`
 
 error: the inner argument implements the required traits
   --> $DIR/general.rs:35:10
@@ -49,10 +49,10 @@ LL |     let _ = std::fs::write("x", <_ as AsRef<str>>::as_ref(""));
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `""`
 
 error: the receiver implements the required traits
-  --> $DIR/general.rs:43:35
+  --> $DIR/general.rs:43:33
    |
-LL |     let _ = std::fs::write("x", "".deref());
-   |                                   ^^^^^^^^ help: remove this
+LL |     let _ = std::fs::write("x", s.deref());
+   |                                 ^^^^^^^^^ help: use: `&s`
 
 error: the receiver implements the required traits
   --> $DIR/general.rs:45:10
@@ -187,70 +187,76 @@ LL |     let _ = is_empty_os(osstring.clone().into_boxed_os_str());
    |                                         ^^^^^^^^^^^^^^^^^^^^ help: remove this
 
 error: the receiver implements the required traits
-  --> $DIR/general.rs:78:32
+  --> $DIR/general.rs:77:48
+   |
+LL |     let _ = os_string_or_bytes(osstring.clone().into_os_str_bytes());
+   |                                                ^^^^^^^^^^^^^^^^^^^^ help: remove this
+
+error: the receiver implements the required traits
+  --> $DIR/general.rs:79:32
    |
 LL |     let _ = std::fs::write(path.as_os_str(), "");
    |                                ^^^^^^^^^^^^ help: remove this
 
 error: the receiver implements the required traits
-  --> $DIR/general.rs:79:46
+  --> $DIR/general.rs:80:46
    |
 LL |     let _ = std::fs::write(PathBuf::from("x").as_mut_os_str(), "");
    |                                              ^^^^^^^^^^^^^^^^ help: remove this
 
 error: the receiver implements the required traits
-  --> $DIR/general.rs:80:46
+  --> $DIR/general.rs:81:46
    |
 LL |     let _ = std::fs::write(PathBuf::from("x").into_boxed_path().into_path_buf(), "");
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this
 
 error: the receiver implements the required traits
-  --> $DIR/general.rs:81:41
+  --> $DIR/general.rs:82:41
    |
 LL |     let _ = Command::new("ls").args(path.iter());
    |                                         ^^^^^^^ help: remove this
 
 error: the inner argument implements the required traits
-  --> $DIR/general.rs:82:28
+  --> $DIR/general.rs:83:28
    |
 LL |     let _ = std::fs::write(Path::new("x"), "");
    |                            ^^^^^^^^^^^^^^ help: use: `"x"`
 
 error: the receiver implements the required traits
-  --> $DIR/general.rs:83:32
+  --> $DIR/general.rs:84:32
    |
 LL |     let _ = std::fs::write(path.to_path_buf(), "");
    |                                ^^^^^^^^^^^^^^ help: remove this
 
 error: the receiver implements the required traits
-  --> $DIR/general.rs:85:28
+  --> $DIR/general.rs:86:28
    |
 LL |     let _ = std::fs::write(path_buf.as_mut_os_string(), "");
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `&mut path_buf`
 
 error: the receiver implements the required traits
-  --> $DIR/general.rs:86:28
+  --> $DIR/general.rs:87:28
    |
 LL |     let _ = std::fs::write(path_buf.as_path(), "");
    |                            ^^^^^^^^^^^^^^^^^^ help: use: `&path_buf`
 
 error: the receiver implements the required traits
-  --> $DIR/general.rs:87:44
+  --> $DIR/general.rs:88:44
    |
 LL |     let _ = std::fs::write(path_buf.clone().into_os_string(), "");
    |                                            ^^^^^^^^^^^^^^^^^ help: remove this
 
 error: the receiver implements the required traits
-  --> $DIR/general.rs:89:28
+  --> $DIR/general.rs:90:28
    |
 LL |     let _ = std::fs::write(tempdir.path(), "");
    |                            ^^^^^^^^^^^^^^ help: use: `&tempdir`
 
 error: the receiver implements the required traits
-  --> $DIR/general.rs:90:28
+  --> $DIR/general.rs:91:28
    |
 LL |     let _ = std::fs::write(tempfile.path(), "");
    |                            ^^^^^^^^^^^^^^^ help: use: `&tempfile`
 
-error: aborting due to 42 previous errors
+error: aborting due to 43 previous errors
 

--- a/examples/testing/clippy/Cargo.lock
+++ b/examples/testing/clippy/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
 [[package]]
 name = "clippy_lints"
 version = "0.1.74"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=acdffd791b31d96cdeb15368132e8ca91f2089af#acdffd791b31d96cdeb15368132e8ca91f2089af"
 dependencies = [
  "arrayvec",
  "cargo_metadata 0.15.4",
@@ -169,7 +169,7 @@ dependencies = [
 [[package]]
 name = "clippy_utils"
 version = "0.1.74"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=acdffd791b31d96cdeb15368132e8ca91f2089af#acdffd791b31d96cdeb15368132e8ca91f2089af"
 dependencies = [
  "arrayvec",
  "if_chain",
@@ -221,7 +221,7 @@ dependencies = [
 [[package]]
 name = "declare_clippy_lint"
 version = "0.1.74"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=acdffd791b31d96cdeb15368132e8ca91f2089af#acdffd791b31d96cdeb15368132e8ca91f2089af"
 dependencies = [
  "itertools",
  "quote",

--- a/examples/testing/clippy/Cargo.lock
+++ b/examples/testing/clippy/Cargo.lock
@@ -145,8 +145,8 @@ dependencies = [
 
 [[package]]
 name = "clippy_lints"
-version = "0.1.73"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=1d334696587ac22b3a9e651e7ac684ac9e0697b2#1d334696587ac22b3a9e651e7ac684ac9e0697b2"
+version = "0.1.74"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "cargo_metadata 0.15.4",
@@ -168,8 +168,8 @@ dependencies = [
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.73"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=1d334696587ac22b3a9e651e7ac684ac9e0697b2#1d334696587ac22b3a9e651e7ac684ac9e0697b2"
+version = "0.1.74"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "arrayvec",
  "if_chain",
@@ -220,8 +220,8 @@ dependencies = [
 
 [[package]]
 name = "declare_clippy_lint"
-version = "0.1.73"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=1d334696587ac22b3a9e651e7ac684ac9e0697b2#1d334696587ac22b3a9e651e7ac684ac9e0697b2"
+version = "0.1.74"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=080b587854a73f2a8cbaecff1884860a78e2ff37#080b587854a73f2a8cbaecff1884860a78e2ff37"
 dependencies = [
  "itertools",
  "quote",

--- a/examples/testing/clippy/Cargo.toml
+++ b/examples/testing/clippy/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-clippy_lints = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_lints = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
 serde_json = "1.0"
 
 dylint_internal = { path = "../../../internal" }

--- a/examples/testing/clippy/Cargo.toml
+++ b/examples/testing/clippy/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-clippy_lints = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
+clippy_lints = { git = "https://github.com/rust-lang/rust-clippy", rev = "acdffd791b31d96cdeb15368132e8ca91f2089af" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "acdffd791b31d96cdeb15368132e8ca91f2089af" }
 serde_json = "1.0"
 
 dylint_internal = { path = "../../../internal" }

--- a/examples/testing/clippy/rust-toolchain
+++ b/examples/testing/clippy/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-07-14"
+channel = "nightly-2023-08-24"
 # smoelius: The `or_fun_call` test passes only if `rust-src` is installed.
 # smoelius: `rust-src` no longer seems to be necessary.
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/examples/testing/clippy/tests/ui.rs
+++ b/examples/testing/clippy/tests/ui.rs
@@ -37,11 +37,14 @@ fn ui() {
     // https://github.com/rust-lang/rust-clippy/blob/master/tests/compile-test.rs). This can happen
     // as a result of using a shared target directory. The workaround I have adopted is to use a
     // temporary target directory.
-    let target_dir = tempdir_in(env!("CARGO_MANIFEST_DIR")).unwrap();
+    let target_dir = tempdir_in(".").unwrap();
+
+    // smoelius: A non-canonical temporary current directory seems to cause problems for `ui_test`.
+    let tempdir_path = tempdir.path().canonicalize().unwrap();
 
     let mut command = dylint_internal::cargo::test("clippy", false);
     command
-        .current_dir(&tempdir)
+        .current_dir(tempdir_path)
         .envs([
             (env::CARGO_TARGET_DIR, &*target_dir.path().to_string_lossy()),
             (env::DYLINT_LIBS, &dylint_libs),

--- a/examples/testing/clippy/tests/ui.rs
+++ b/examples/testing/clippy/tests/ui.rs
@@ -22,6 +22,17 @@ fn ui() {
     // let src_base = tempdir.path().join("tests/ui");
     // adjust_macro_use_imports_test(&src_base).unwrap();
 
+    // smoelius: The `5041_allow_dev_build` test is flaky on Windows. See:
+    // https://github.com/rust-lang/rust-clippy/issues/11489
+    // Disable the test for now.
+    #[cfg(windows)]
+    std::fs::remove_dir_all(
+        tempdir
+            .path()
+            .join("tests/ui-cargo/multiple_crate_versions/5041_allow_dev_build"),
+    )
+    .unwrap();
+
     // smoelius: `DYLINT_LIBRARY_PATH` must be set before `dylint_libs` is called.
     // smoelius: This is no longer true. See comment in `dylint_testing::initialize`.
     let metadata = dylint_internal::cargo::current_metadata().unwrap();

--- a/examples/testing/straggler/Cargo.lock
+++ b/examples/testing/straggler/Cargo.lock
@@ -113,8 +113,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.72"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=dd8e44c5a22ab646821252604420c5bb82c36aa9#dd8e44c5a22ab646821252604420c5bb82c36aa9"
+version = "0.1.73"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=1d334696587ac22b3a9e651e7ac684ac9e0697b2#1d334696587ac22b3a9e651e7ac684ac9e0697b2"
 dependencies = [
  "arrayvec",
  "if_chain",

--- a/examples/testing/straggler/Cargo.toml
+++ b/examples/testing/straggler/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # smoelius: `straggler` is intentionally held back for testing purposes.
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "dd8e44c5a22ab646821252604420c5bb82c36aa9" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
 
 dylint_linting = { path = "../../../utils/linting" }
 

--- a/examples/testing/straggler/rust-toolchain
+++ b/examples/testing/straggler/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
 # smoelius: `straggler` is intentionally held back for testing purposes.
-channel = "nightly-2023-06-29"
+channel = "nightly-2023-07-14"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/internal/src/env.rs
+++ b/internal/src/env.rs
@@ -7,6 +7,7 @@ macro_rules! declare_const {
 }
 
 declare_const!(CARGO_HOME);
+declare_const!(CARGO_INCREMENTAL);
 declare_const!(CARGO_MANIFEST_DIR);
 declare_const!(CARGO_PKG_NAME);
 declare_const!(CARGO_PRIMARY_PACKAGE);

--- a/internal/src/packaging.rs
+++ b/internal/src/packaging.rs
@@ -47,7 +47,7 @@ pub fn isolate(path: &Path) -> Result<()> {
         .with_context(|| format!("Could not open `{}`", manifest.to_string_lossy()))?;
 
     writeln!(file)
-        .and_then(|_| writeln!(file, "[workspace]"))
+        .and_then(|()| writeln!(file, "[workspace]"))
         .with_context(|| format!("Could not write to `{}`", manifest.to_string_lossy()))?;
 
     Ok(())
@@ -71,8 +71,8 @@ pub fn use_local_packages(path: &Path) -> Result<()> {
     // smoelius: `use_local_packages` broke when `dylint_linting` was removed from the workspace.
     // For now, add `dylint_linting` manually.
     writeln!(file)
-        .and_then(|_| writeln!(file, "[patch.crates-io]"))
-        .and_then(|_| {
+        .and_then(|()| writeln!(file, "[patch.crates-io]"))
+        .and_then(|()| {
             writeln!(
                 file,
                 r#"dylint_linting = {{ path = "{}" }}"#,

--- a/internal/template/Cargo.toml~
+++ b/internal/template/Cargo.toml~
@@ -10,7 +10,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "acdffd791b31d96cdeb15368132e8ca91f2089af" }
 dylint_linting = "2.3.0"
 if_chain = "1.0.2"
 

--- a/internal/template/Cargo.toml~
+++ b/internal/template/Cargo.toml~
@@ -10,7 +10,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "1d334696587ac22b3a9e651e7ac684ac9e0697b2" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "080b587854a73f2a8cbaecff1884860a78e2ff37" }
 dylint_linting = "2.3.0"
 if_chain = "1.0.2"
 

--- a/internal/template/rust-toolchain
+++ b/internal/template/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-07-14"
+channel = "nightly-2023-08-24"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/scripts/upgrade_examples.sh
+++ b/scripts/upgrade_examples.sh
@@ -15,16 +15,7 @@ cd "$WORKSPACE"
 
 CARGO_DYLINT='timeout 10m cargo run -p cargo-dylint -- dylint'
 
-for EXAMPLE in examples/*/* internal/template; do
-    if [[ ! -d "$EXAMPLE" ]]; then
-        continue
-    fi
-
-    # smoelius: `straggler` is handled with `clippy` below.
-    if [[ "$EXAMPLE" = 'examples/testing/straggler' ]]; then
-        continue
-    fi
-
+for EXAMPLE in examples/general examples/supplementary examples/restriction/* examples/testing/clippy internal/template; do
     # smoelius: If the example's directory has changes, assume the example was already upgraded and
     # the script had to be restarted.
     if ! git diff --exit-code "$EXAMPLE"; then


### PR DESCRIPTION
~What goes wrong if we don't canonicalize `local_crate_source_file` in `dylint_linting`?~

This is a reformulation of #819. (It is easier to use this PR than to update that one.)