### PR TITLE
Make `curl-sys` an optional dependency

### DIFF
--- a/dylint/Cargo.toml
+++ b/dylint/Cargo.toml
@@ -32,7 +32,9 @@ walkdir = "2.4"
 
 # smoelius: Work around: https://github.com/curl/curl/issues/11893
 # See: https://github.com/alexcrichton/curl-rust/issues/524#issuecomment-1703325064
-curl-sys = { version = "0.4", features = ["force-system-lib-on-osx"] }
+curl-sys = { version = "0.4", features = [
+    "force-system-lib-on-osx",
+], optional = true }
 
 dylint_internal = { version = "=2.4.2", path = "../internal", features = [
     "git",
@@ -55,7 +57,15 @@ dylint_internal = { version = "=2.4.2", path = "../internal", features = [
 
 [features]
 default = ["metadata"]
-metadata = ["cargo", "cargo-platform", "cargo-util", "glob", "if_chain", "toml"]
+metadata = [
+    "cargo",
+    "cargo-platform",
+    "cargo-util",
+    "curl-sys",
+    "glob",
+    "if_chain",
+    "toml",
+]
 package_options = [
     "if_chain",
     "dylint_internal/clippy_utils",

--- a/examples/general/Cargo.lock
+++ b/examples/general/Cargo.lock
@@ -209,21 +209,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl-sys"
-version = "0.4.66+curl-8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,7 +285,6 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "cargo_metadata",
- "curl-sys",
  "dirs",
  "dylint_internal",
  "heck",

--- a/examples/restriction/assert_eq_arg_misordering/Cargo.lock
+++ b/examples/restriction/assert_eq_arg_misordering/Cargo.lock
@@ -174,21 +174,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl-sys"
-version = "0.4.66+curl-8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,7 +238,6 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "cargo_metadata",
- "curl-sys",
  "dirs",
  "dylint_internal",
  "heck",

--- a/examples/restriction/collapsible_unwrap/Cargo.lock
+++ b/examples/restriction/collapsible_unwrap/Cargo.lock
@@ -176,21 +176,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl-sys"
-version = "0.4.66+curl-8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,7 +240,6 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "cargo_metadata",
- "curl-sys",
  "dirs",
  "dylint_internal",
  "heck",

--- a/examples/restriction/const_path_join/Cargo.lock
+++ b/examples/restriction/const_path_join/Cargo.lock
@@ -176,21 +176,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl-sys"
-version = "0.4.66+curl-8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,7 +240,6 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "cargo_metadata",
- "curl-sys",
  "dirs",
  "dylint_internal",
  "heck",

--- a/examples/restriction/derive_opportunity/Cargo.lock
+++ b/examples/restriction/derive_opportunity/Cargo.lock
@@ -164,21 +164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl-sys"
-version = "0.4.66+curl-8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys",
-]
-
-[[package]]
 name = "derive_opportunity"
 version = "2.4.2"
 dependencies = [
@@ -258,7 +243,6 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "cargo_metadata",
- "curl-sys",
  "dirs",
  "dylint_internal",
  "heck",

--- a/examples/restriction/env_literal/Cargo.lock
+++ b/examples/restriction/env_literal/Cargo.lock
@@ -164,21 +164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl-sys"
-version = "0.4.66+curl-8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,7 +228,6 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "cargo_metadata",
- "curl-sys",
  "dirs",
  "dylint_internal",
  "heck",

--- a/examples/restriction/inconsistent_qualification/Cargo.lock
+++ b/examples/restriction/inconsistent_qualification/Cargo.lock
@@ -164,21 +164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl-sys"
-version = "0.4.66+curl-8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys",
-]
-
-[[package]]
 name = "diesel"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,7 +258,6 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "cargo_metadata",
- "curl-sys",
  "dirs",
  "dylint_internal",
  "heck",

--- a/examples/restriction/misleading_variable_name/Cargo.lock
+++ b/examples/restriction/misleading_variable_name/Cargo.lock
@@ -164,21 +164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl-sys"
-version = "0.4.66+curl-8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,7 +228,6 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "cargo_metadata",
- "curl-sys",
  "dirs",
  "dylint_internal",
  "heck",

--- a/examples/restriction/missing_doc_comment_openai/Cargo.lock
+++ b/examples/restriction/missing_doc_comment_openai/Cargo.lock
@@ -258,7 +258,6 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "cargo_metadata",
- "curl-sys",
  "dirs",
  "dylint_internal",
  "heck",

--- a/examples/restriction/overscoped_allow/Cargo.lock
+++ b/examples/restriction/overscoped_allow/Cargo.lock
@@ -186,21 +186,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl-sys"
-version = "0.4.66+curl-8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,7 +262,6 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "cargo_metadata",
- "curl-sys",
  "dirs",
  "dylint_internal",
  "heck",

--- a/examples/restriction/question_mark_in_expression/Cargo.lock
+++ b/examples/restriction/question_mark_in_expression/Cargo.lock
@@ -164,21 +164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl-sys"
-version = "0.4.66+curl-8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,7 +228,6 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "cargo_metadata",
- "curl-sys",
  "dirs",
  "dylint_internal",
  "heck",

--- a/examples/restriction/ref_aware_redundant_closure_for_method_calls/Cargo.lock
+++ b/examples/restriction/ref_aware_redundant_closure_for_method_calls/Cargo.lock
@@ -164,21 +164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl-sys"
-version = "0.4.66+curl-8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,7 +228,6 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "cargo_metadata",
- "curl-sys",
  "dirs",
  "dylint_internal",
  "heck",

--- a/examples/restriction/suboptimal_pattern/Cargo.lock
+++ b/examples/restriction/suboptimal_pattern/Cargo.lock
@@ -164,21 +164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl-sys"
-version = "0.4.66+curl-8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,7 +228,6 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "cargo_metadata",
- "curl-sys",
  "dirs",
  "dylint_internal",
  "heck",

--- a/examples/restriction/try_io_result/Cargo.lock
+++ b/examples/restriction/try_io_result/Cargo.lock
@@ -164,21 +164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl-sys"
-version = "0.4.66+curl-8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,7 +228,6 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "cargo_metadata",
- "curl-sys",
  "dirs",
  "dylint_internal",
  "heck",

--- a/examples/supplementary/Cargo.lock
+++ b/examples/supplementary/Cargo.lock
@@ -177,21 +177,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl-sys"
-version = "0.4.66+curl-8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,7 +241,6 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "cargo_metadata",
- "curl-sys",
  "dirs",
  "dylint_internal",
  "heck",

--- a/examples/testing/clippy/Cargo.lock
+++ b/examples/testing/clippy/Cargo.lock
@@ -219,21 +219,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl-sys"
-version = "0.4.66+curl-8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys",
-]
-
-[[package]]
 name = "declare_clippy_lint"
 version = "0.1.74"
 source = "git+https://github.com/rust-lang/rust-clippy?rev=acdffd791b31d96cdeb15368132e8ca91f2089af#acdffd791b31d96cdeb15368132e8ca91f2089af"
@@ -308,7 +293,6 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "cargo_metadata 0.18.0",
- "curl-sys",
  "dirs",
  "dylint_internal",
  "heck",

--- a/examples/testing/straggler/Cargo.lock
+++ b/examples/testing/straggler/Cargo.lock
@@ -164,21 +164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl-sys"
-version = "0.4.66+curl-8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,7 +228,6 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "cargo_metadata",
- "curl-sys",
  "dirs",
  "dylint_internal",
  "heck",


### PR DESCRIPTION
#858 made `curl-sys` a non-optional dependency of the `dylint` package. This had unintended side effects, e.g., causing all of the example lints to transitively depend on `curl-sys`. The present PR rectifies the situation.