### PR TITLE
Add function name to the non local effect lint

### DIFF
--- a/examples/general/Cargo.lock
+++ b/examples/general/Cargo.lock
@@ -219,6 +219,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +702,7 @@ version = "2.6.0"
 dependencies = [
  "bitflags 2.4.1",
  "clippy_utils",
+ "derivative",
  "dylint_linting",
  "dylint_testing",
  "if_chain",
@@ -888,7 +900,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn",
+ "syn 2.0.48",
  "walkdir",
 ]
 
@@ -990,7 +1002,7 @@ checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1022,6 +1034,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1104,7 +1127,7 @@ checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1200,7 +1223,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/examples/general/non_local_effect_before_error_return/Cargo.toml
+++ b/examples/general/non_local_effect_before_error_return/Cargo.toml
@@ -25,6 +25,7 @@ bitflags = "2.4"
 once_cell = "1.19"
 
 dylint_testing = { path = "../../../utils/testing" }
+derivative = "2.2.0"
 
 [features]
 rlib = ["dylint_linting/constituent"]

--- a/examples/general/non_local_effect_before_error_return/Cargo.toml
+++ b/examples/general/non_local_effect_before_error_return/Cargo.toml
@@ -22,10 +22,10 @@ dylint_linting = { path = "../../../utils/linting" }
 
 [dev-dependencies]
 bitflags = "2.4"
+derivative = "2.2.0"
 once_cell = "1.19"
 
 dylint_testing = { path = "../../../utils/testing" }
-derivative = "2.2.0"
 
 [features]
 rlib = ["dylint_linting/constituent"]

--- a/examples/general/non_local_effect_before_error_return/src/lib.rs
+++ b/examples/general/non_local_effect_before_error_return/src/lib.rs
@@ -224,7 +224,7 @@ fn is_call_with_mut_ref<'tcx>(
         if locals.iter().any(|local| is_mut_ref_arg(mir, local))
             || constants.iter().any(|constant| is_const_ref(constant));
         then {
-            let func_string = format!("{:#?}", func);
+            let func_string = format!("{func:#?}");
             Some(FunctionStringAndSpan(func_string, *fn_span))
         } else {
             None

--- a/examples/general/non_local_effect_before_error_return/src/lib.rs
+++ b/examples/general/non_local_effect_before_error_return/src/lib.rs
@@ -158,7 +158,7 @@ impl<'tcx> LateLintPass<'tcx> for NonLocalEffectBeforeErrorReturn {
                                 cx,
                                 NON_LOCAL_EFFECT_BEFORE_ERROR_RETURN,
                                 func_span,
-                                &format!("call to `{:?}` with mutable reference before error return", func),
+                                &format!("call to `{func:?}` with mutable reference before error return"),
                                 error_note(span),
                             );
                         }

--- a/examples/general/non_local_effect_before_error_return/ui/main.rs
+++ b/examples/general/non_local_effect_before_error_return/ui/main.rs
@@ -253,3 +253,13 @@ mod downcast {
         Ok(())
     }
 }
+
+use derivative::Derivative;
+
+#[derive(Derivative)]
+#[derivative(Debug)]
+struct Foo {
+    foo: u8,
+    #[derivative(Debug = "ignore")]
+    bar: u8,
+}

--- a/examples/general/non_local_effect_before_error_return/ui/main.stderr
+++ b/examples/general/non_local_effect_before_error_return/ui/main.stderr
@@ -12,7 +12,7 @@ LL |     Err(VarError::NotPresent)
    = note: `-D non-local-effect-before-error-return` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(non_local_effect_before_error_return)]`
 
-error: call with mutable reference before error return
+error: call to std::vec::Vec::<u32>::push with mutable reference before error return
   --> $DIR/main.rs:28:8
    |
 LL |     xs.push(0);
@@ -36,7 +36,7 @@ note: error is determined here
 LL |     let _ = var("X")?;
    |             ^^^^^^^^^
 
-error: call with mutable reference before error return
+error: call to std::vec::Vec::<u32>::push with mutable reference before error return
   --> $DIR/main.rs:39:8
    |
 LL |     xs.push(0);
@@ -60,7 +60,7 @@ note: error is determined here
 LL |     let result = Err(VarError::NotPresent);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: call with mutable reference before error return
+error: call to std::vec::Vec::<u32>::push with mutable reference before error return
   --> $DIR/main.rs:64:8
    |
 LL |     xs.push(0);
@@ -84,7 +84,7 @@ note: error is determined here
 LL |     match result {
    |     ^^^^^^^^^^^^
 
-error: call with mutable reference before error return
+error: call to std::vec::Vec::<u32>::push with mutable reference before error return
   --> $DIR/main.rs:106:16
    |
 LL |             xs.push(0);
@@ -120,7 +120,7 @@ note: error is determined here
 LL |         Err(Error::Two)
    |         ^^^^^^^^^^^^^^^
 
-error: call with mutable reference before error return
+error: call to bitflags::_::<impl bitflags::Flags>::insert with mutable reference before error return
   --> $DIR/main.rs:185:15
    |
 LL |         flags.insert(flag);
@@ -132,7 +132,7 @@ note: error is determined here
 LL |             return Err(());
    |                    ^^^^^^^
 
-error: call with mutable reference before error return
+error: call to std::string::String::push with mutable reference before error return
   --> $DIR/main.rs:202:11
    |
 LL |         s.push('x');
@@ -144,7 +144,7 @@ note: error is determined here
 LL |         Err(())
    |         ^^^^^^^
 
-error: call with mutable reference before error return
+error: call to std::process::Command::env::<&str, &str> with mutable reference before error return
   --> $DIR/main.rs:212:10
    |
 LL |         .env("RUST_LOG", "debug")

--- a/examples/general/non_local_effect_before_error_return/ui/main.stderr
+++ b/examples/general/non_local_effect_before_error_return/ui/main.stderr
@@ -12,7 +12,7 @@ LL |     Err(VarError::NotPresent)
    = note: `-D non-local-effect-before-error-return` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(non_local_effect_before_error_return)]`
 
-error: call to std::vec::Vec::<u32>::push with mutable reference before error return
+error: call to `std::vec::Vec::<u32>::push` with mutable reference before error return
   --> $DIR/main.rs:28:8
    |
 LL |     xs.push(0);
@@ -36,7 +36,7 @@ note: error is determined here
 LL |     let _ = var("X")?;
    |             ^^^^^^^^^
 
-error: call to std::vec::Vec::<u32>::push with mutable reference before error return
+error: call to `std::vec::Vec::<u32>::push` with mutable reference before error return
   --> $DIR/main.rs:39:8
    |
 LL |     xs.push(0);
@@ -60,7 +60,7 @@ note: error is determined here
 LL |     let result = Err(VarError::NotPresent);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: call to std::vec::Vec::<u32>::push with mutable reference before error return
+error: call to `std::vec::Vec::<u32>::push` with mutable reference before error return
   --> $DIR/main.rs:64:8
    |
 LL |     xs.push(0);
@@ -84,7 +84,7 @@ note: error is determined here
 LL |     match result {
    |     ^^^^^^^^^^^^
 
-error: call to std::vec::Vec::<u32>::push with mutable reference before error return
+error: call to `std::vec::Vec::<u32>::push` with mutable reference before error return
   --> $DIR/main.rs:106:16
    |
 LL |             xs.push(0);
@@ -120,7 +120,7 @@ note: error is determined here
 LL |         Err(Error::Two)
    |         ^^^^^^^^^^^^^^^
 
-error: call to bitflags::_::<impl bitflags::Flags>::insert with mutable reference before error return
+error: call to `bitflags::_::<impl bitflags::Flags>::insert` with mutable reference before error return
   --> $DIR/main.rs:185:15
    |
 LL |         flags.insert(flag);
@@ -132,7 +132,7 @@ note: error is determined here
 LL |             return Err(());
    |                    ^^^^^^^
 
-error: call to std::string::String::push with mutable reference before error return
+error: call to `std::string::String::push` with mutable reference before error return
   --> $DIR/main.rs:202:11
    |
 LL |         s.push('x');
@@ -144,7 +144,7 @@ note: error is determined here
 LL |         Err(())
    |         ^^^^^^^
 
-error: call to std::process::Command::env::<&str, &str> with mutable reference before error return
+error: call to `std::process::Command::env::<&str, &str>` with mutable reference before error return
   --> $DIR/main.rs:212:10
    |
 LL |         .env("RUST_LOG", "debug")
@@ -156,5 +156,11 @@ error: assignment to dereference before error return
 LL |         *flag = true;
    |         ^^^^^^^^^^^^
 
-error: aborting due to 14 previous errors
+error: call to `std::fmt::DebugStruct::<'_, '_>::field` with mutable reference before error return
+  --> $DIR/main.rs:261:8
+   |
+LL | struct Foo {
+   |        ^^^
+
+error: aborting due to 15 previous errors
 


### PR DESCRIPTION
This PR adds the called function formatted string to the non-local-effect lint message. 
This allows knowing which function triggered the lint if the issue is in a derived/expanded function (e.g., in a structure declaration).