### PR TITLE
Print `dep_name` instead of "dummy package"

### DIFF
--- a/dylint/src/metadata/cli/mod.rs
+++ b/dylint/src/metadata/cli/mod.rs
@@ -148,7 +148,7 @@ fn git_dependency_root(url: &str, details: &DetailedTomlDependency) -> Result<Pa
         BTreeMap::new()
     };
 
-    cargo_fetch(package.path())?;
+    cargo_fetch(&dep_name, package.path())?;
 
     // smoelius: `cargo metadata` will fail if `cargo fetch` had to create a new checkouts
     // subdirectory.
@@ -239,11 +239,11 @@ fn inject_dummy_dependencies(
     Ok(injected_dependencies)
 }
 
-fn cargo_fetch(path: &Path) -> Result<()> {
+fn cargo_fetch(dep_name: &str, path: &Path) -> Result<()> {
     // smoelius: `cargo fetch` could fail, e.g., if a new checkouts subdirectory had to be created.
     // But the command should still be executed.
     // smoelius: Since stdout and stderr are captured, there is no need to use `.quiet(true)`.
-    let _output = dylint_internal::cargo::fetch("dummy package")
+    let _output = dylint_internal::cargo::fetch(&format!("`{dep_name}`"))
         .stable(true)
         .build()
         .args([


### PR DESCRIPTION
Bandaid until we come up with a better API for #1014.