### PR TITLE
Update `boundary_toolchains` test

### DIFF
--- a/cargo-dylint/tests/boundary_toolchains.rs
+++ b/cargo-dylint/tests/boundary_toolchains.rs
@@ -26,12 +26,14 @@ const BOUNDARIES: &[(&str, &str)] = &[
     // https://github.com/rust-lang/rust/pull/119063
     // https://github.com/rust-lang/rust/commit/cda4736f1eaad8af6f49388baa9b7e480df8e329
     ("2023-12-18", "2023-12-19"),
+    // smoelius: `cargo-platform v0.1.8` requires rustc 1.73 or newer.
     // https://github.com/rust-lang/rust/pull/112692
     // https://github.com/rust-lang/rust/commit/b6144cd843d6eb6acc086797ea37e0c69c892b90
-    ("2023-06-28", "2023-06-29"),
+    // ("2023-06-28", "2023-06-29"),
     // https://github.com/rust-lang/rust/pull/111748
     // https://github.com/rust-lang/rust/commit/70e04bd88d85cab8ed110ace5a278fab106d0ef5
-    ("2023-05-29", "2023-05-30"),
+    // ("2023-05-29", "2023-05-30"),
+
     // smoelius: `cargo-util v0.2.7` requires rustc 1.72.0 or newer.
     // https://github.com/rust-lang/rust/pull/111633
     // https://github.com/rust-lang/rust/commit/08efb9d652c840715d15954592426e2befe13b36

--- a/cargo-dylint/tests/list.rs
+++ b/cargo-dylint/tests/list.rs
@@ -20,11 +20,11 @@ use std::{
 };
 use tempfile::tempdir;
 
-const CHANNEL_A: &str = "nightly-2023-06-29";
-const CHANNEL_B: &str = "nightly-2023-07-14";
+const CHANNEL_A: &str = "nightly-2023-11-16";
+const CHANNEL_B: &str = "nightly-2024-02-08";
 
-const CLIPPY_UTILS_REV_A: &str = "dd8e44c5a22ab646821252604420c5bb82c36aa9";
-const CLIPPY_UTILS_REV_B: &str = "1d334696587ac22b3a9e651e7ac684ac9e0697b2";
+const CLIPPY_UTILS_REV_A: &str = "edb720b199083f4107b858a8761648065bf38d86";
+const CLIPPY_UTILS_REV_B: &str = "60cb29c5e4f9772685c9873752196725c946a849";
 
 #[test]
 fn one_name_multiple_toolchains() {

--- a/cargo-dylint/tests/package_options.rs
+++ b/cargo-dylint/tests/package_options.rs
@@ -13,7 +13,8 @@ use tempfile::tempdir;
 // smoelius: Dylint's MSRV was recently bumped to 1.68.
 // smoelius: `home v0.5.9` (2013-12-15) requires rustc 1.70.0 or newer.
 // smoelius: `cargo-util v0.2.7` requires rustc 1.72.0 or newer.
-const RUST_VERSION: &str = "1.72.0";
+// smoelius: `cargo-platform v0.1.8` requires rustc 1.73 or newer.
+const RUST_VERSION: &str = "1.73.0";
 
 #[test]
 fn new_package() {


### PR DESCRIPTION
`cargo-platform v0.1.8` requires rustc 1.73 or newer.