### PR TITLE
Make `DiagCtxt::warn` a disallowed method

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,4 @@
 disallowed-methods = [
+    { path = "rustc_errors::DiagCtxt::warn", reason = "ensure `DiagCtxt::warn` is not called from `register_lints`" },
     { path = "std::process::Command::output", reason = "use `CommandExt::logged_output`" },
 ]

--- a/examples/experimental/missing_doc_comment_openai/src/lib.rs
+++ b/examples/experimental/missing_doc_comment_openai/src/lib.rs
@@ -131,6 +131,7 @@ impl MissingDocCommentOpenai {
 impl<'tcx> LateLintPass<'tcx> for MissingDocCommentOpenai {
     fn check_crate(&mut self, cx: &LateContext<'tcx>) {
         if std::env::var(OPENAI_API_KEY).is_err() {
+            #[allow(clippy::disallowed_methods)]
             cx.sess().dcx().warn(format!(
                 "`missing_doc_comment_openai` suggestions are disabled because environment \
                  variable `{OPENAI_API_KEY}` is not set"

--- a/examples/general/non_local_effect_before_error_return/src/visit_error_paths.rs
+++ b/examples/general/non_local_effect_before_error_return/src/visit_error_paths.rs
@@ -257,6 +257,7 @@ where
                 FnKind::ItemFn(ident, _, _) | FnKind::Method(ident, _) => format!("`{ident}`"),
                 FnKind::Closure => "closure".to_owned(),
             };
+            #[allow(clippy::disallowed_methods)]
             self.cx.sess().dcx().warn(format!(
                 "reached work limit ({}) while checking {}; set `{}.work_limit` in `dylint.toml` \
                  to override",

--- a/examples/general/non_thread_safe_call_in_test/src/late.rs
+++ b/examples/general/non_thread_safe_call_in_test/src/late.rs
@@ -65,6 +65,7 @@ impl_lint_pass!(NonThreadSafeCallInTest => [NON_THREAD_SAFE_CALL_IN_TEST]);
 impl<'tcx> LateLintPass<'tcx> for NonThreadSafeCallInTest {
     fn check_crate(&mut self, cx: &LateContext<'tcx>) {
         if !cx.sess().opts.test {
+            #[allow(clippy::disallowed_methods)]
             cx.sess().dcx().warn(
                 "`non_thread_safe_call_in_test` is unlikely to be effective as `--test` was not \
                  passed to rustc",


### PR DESCRIPTION
This is a [95% solution](https://github.com/trailofbits/dylint/issues/654#issuecomment-1849753754) to #654.

The 100% solution would be a custom lint.