### PR TITLE
Add `commented_code` false positive

### DIFF
--- a/examples/supplementary/commented_code/ui/main.rs
+++ b/examples/supplementary/commented_code/ui/main.rs
@@ -38,3 +38,8 @@ fn negative_tests() {
     /// doc_comment();
     foo(0);
 }
+
+fn single_identifier() {
+    // smoelius: This is a "false positive." Ideally, the lint would not fire on the next line.
+    // Identifier
+}


### PR DESCRIPTION
`commented_code` should not flag single identifiers.

This PR is just a placeholder until I produce a fix.