### PR TITLE
Add `#![feature(rustc_private)]` to driver's main.rs

### DIFF
--- a/cargo-dylint/tests/supply_chain/cargo_lib/aarch64-apple-darwin.json
+++ b/cargo-dylint/tests/supply_chain/cargo_lib/aarch64-apple-darwin.json
@@ -1376,7 +1376,7 @@
         "id": 6289,
         "kind": "user",
         "login": "str4d",
-        "name": null
+        "name": "Jack Grigg"
       }
     ],
     "fiat-crypto": [
@@ -2097,7 +2097,7 @@
         "id": 6289,
         "kind": "user",
         "login": "str4d",
-        "name": null
+        "name": "Jack Grigg"
       }
     ],
     "hashbrown": [

--- a/cargo-dylint/tests/supply_chain/cargo_lib/x86_64-apple-darwin.json
+++ b/cargo-dylint/tests/supply_chain/cargo_lib/x86_64-apple-darwin.json
@@ -1376,7 +1376,7 @@
         "id": 6289,
         "kind": "user",
         "login": "str4d",
-        "name": null
+        "name": "Jack Grigg"
       }
     ],
     "fiat-crypto": [
@@ -2097,7 +2097,7 @@
         "id": 6289,
         "kind": "user",
         "login": "str4d",
-        "name": null
+        "name": "Jack Grigg"
       }
     ],
     "hashbrown": [

--- a/cargo-dylint/tests/supply_chain/cargo_lib/x86_64-pc-windows-msvc.json
+++ b/cargo-dylint/tests/supply_chain/cargo_lib/x86_64-pc-windows-msvc.json
@@ -1307,7 +1307,7 @@
         "id": 6289,
         "kind": "user",
         "login": "str4d",
-        "name": null
+        "name": "Jack Grigg"
       }
     ],
     "fiat-crypto": [
@@ -2012,7 +2012,7 @@
         "id": 6289,
         "kind": "user",
         "login": "str4d",
-        "name": null
+        "name": "Jack Grigg"
       }
     ],
     "hashbrown": [

--- a/cargo-dylint/tests/supply_chain/cargo_lib/x86_64-unknown-linux-gnu.json
+++ b/cargo-dylint/tests/supply_chain/cargo_lib/x86_64-unknown-linux-gnu.json
@@ -1332,7 +1332,7 @@
         "id": 6289,
         "kind": "user",
         "login": "str4d",
-        "name": null
+        "name": "Jack Grigg"
       }
     ],
     "fiat-crypto": [
@@ -2053,7 +2053,7 @@
         "id": 6289,
         "kind": "user",
         "login": "str4d",
-        "name": null
+        "name": "Jack Grigg"
       }
     ],
     "hashbrown": [

--- a/dylint/src/driver_builder.rs
+++ b/dylint/src/driver_builder.rs
@@ -51,6 +51,8 @@ components = ["llvm-tools-preview", "rustc-dev"]
 }
 
 const MAIN_RS: &str = r"
+#![feature(rustc_private)]
+
 use anyhow::Result;
 use std::env;
 use std::ffi::OsString;


### PR DESCRIPTION
Recently, this seems to have become necessary to build drivers on macOS.