### PR TITLE
Remove `extern crate rustc_attr;` from template

### DIFF
--- a/internal/template/src/lib.rs
+++ b/internal/template/src/lib.rs
@@ -5,7 +5,6 @@
 extern crate rustc_arena;
 extern crate rustc_ast;
 extern crate rustc_ast_pretty;
-extern crate rustc_attr;
 extern crate rustc_data_structures;
 extern crate rustc_errors;
 extern crate rustc_hir;


### PR DESCRIPTION
The crate was recently renamed: https://github.com/rust-lang/rust/pull/134381