### PR TITLE
Allow `deprecated` for `std::env::home_dir`

### DIFF
--- a/cargo-dylint/tests/ci.rs
+++ b/cargo-dylint/tests/ci.rs
@@ -297,7 +297,9 @@ fn duplicate_dependencies() {
 #[test]
 fn hack_feature_powerset_udeps() {
     Command::new("rustup")
-        .env(env::RUSTFLAGS, "-D warnings")
+        // smoelius: `--check-cfg cfg(test)` to work around the following issue:
+        // https://github.com/est31/cargo-udeps/issues/293
+        .env(env::RUSTFLAGS, "-D warnings --check-cfg cfg(test)")
         .args([
             "run",
             "nightly",

--- a/internal/Cargo.toml
+++ b/internal/Cargo.toml
@@ -59,3 +59,6 @@ testing = ["ctor", "env_logger", "packaging"]
 
 [lints]
 workspace = true
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["home"]

--- a/internal/src/home.rs
+++ b/internal/src/home.rs
@@ -15,4 +15,9 @@ pub fn cargo_home() -> Option<PathBuf> {
 pub use home::home_dir;
 
 #[rustversion::since(1.86)]
-pub use std::env::home_dir;
+pub fn home_dir() -> Option<PathBuf> {
+    // smoelius: The `deprecated` attribute hasn't been removed yet:
+    // https://github.com/rust-lang/rust/pull/132515#discussion_r1829715262
+    #[expect(deprecated)]
+    std::env::home_dir()
+}


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/132515#discussion_r1829715262