### PR TITLE
feat#1533: verify  `general` and `supplementary`  registered lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,7 @@ dependencies = [
  "cargo-util",
  "cargo_metadata",
  "dylint_internal",
+ "regex",
  "toml",
  "toml_edit",
  "walkdir",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,15 +9,15 @@ publish = false
 [dev-dependencies]
 cargo-util = { workspace = true }
 cargo_metadata = { workspace = true }
+regex = { workspace = true }
+toml = { workspace = true }
+toml_edit = { workspace = true }
+walkdir = { workspace = true }
 
 dylint_internal = { version = "=4.1.0", path = "../internal", features = [
     "clippy_utils",
     "examples",
 ] }
-regex = { workspace = true }
-toml = { workspace = true }
-toml_edit = { workspace = true }
-walkdir = { workspace = true }
 
 [lints]
 workspace = true

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,14 +9,15 @@ publish = false
 [dev-dependencies]
 cargo-util = { workspace = true }
 cargo_metadata = { workspace = true }
-toml = { workspace = true }
-toml_edit = { workspace = true }
-walkdir = { workspace = true }
 
 dylint_internal = { version = "=4.1.0", path = "../internal", features = [
     "clippy_utils",
     "examples",
 ] }
+regex = { workspace = true }
+toml = { workspace = true }
+toml_edit = { workspace = true }
+walkdir = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Relevant issue #1533 

This test ensures that all lints defined in the "general" and "supplementary" folders are actually registered in the corresponding src/lib.rs file. The process is as follows:
1. Extract expected lints by listing the immediate subdirectories in "general" and "supplementary" (ignoring src and hidden directories) to determine the expected lint module names.
2. Read the src/lib.rs file in both folder and extract registered lints using this regex 
`([a-zA-Z_][a-zA-Z0-9_]*)::register_lints\s*\(` which captures the module name right before the literal `::register_lints` call.
4. Lastly, compare the expected and actually registered lints.

if we were to run the test with the dylint's current state we would get this output:
```bash
---- verify_registered_lints stdout ----

thread 'verify_registered_lints' panicked at cargo-dylint/tests/ci.rs:584:13:
Mismatch in /Users/user/dylint/cargo-dylint/../examples/supplementary:

Missing registered lints: ["local_ref_cell", "nonexistent_path_in_comment"]

Expected: ["commented_code", "escaping_doc_link", "inconsistent_struct_pattern", "local_ref_cell", "nonexistent_path_in_comment", "redundant_reference", "unnamed_constant", "unnecessary_borrow_mut", "unnecessary_conversion_for_trait"]
Actual: ["commented_code", "escaping_doc_link", "inconsistent_struct_pattern", "redundant_reference", "unnamed_constant", "unnecessary_borrow_mut", "unnecessary_conversion_for_trait"]
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Also seeing that `::register_lints` is only used inside of the general and supplementary folders, I figured that using the examples::iter function would be too broad for our check.

This approach is a bit different from the initial that we initially discussed about, because we extract the existing lints with their folder names instead of extracting them from the `cargo metadata`. I'm open to feedback or alternative suggestions!