### PR TITLE
Convert README verification script to a Rust test

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,8 @@ The example libraries are separated into the following three categories:
 - [experimental] - not ready for primetime yet (similar to [Clippy]'s "nursery" category)
 - [testing] - used only for testing purposes
 
+<!-- lint descriptions start -->
+
 ## General
 
 | Example                                                                                  | Description/check                                                      |
@@ -65,6 +67,8 @@ The example libraries are separated into the following three categories:
 | ---------------------------------- | ------------------------------------------------------ |
 | [`clippy`](./testing/clippy)       | All of the Clippy lints as a Dylint library            |
 | [`straggler`](./testing/straggler) | A lint that uses an old toolchain for testing purposes |
+
+<!-- lint descriptions end -->
 
 **Notes**
 


### PR DESCRIPTION
This PR addresses #636 by replacing the bash script (`scripts/update_example_READMEs.sh`) with a Rust-based test that verifies the examples/README.md contents are in sync with the actual examples in the codebase.

The test:
- Walks through all example categories (general, supplementary, restriction, experimental, and testing)
- Extracts example names and descriptions from each Cargo.toml file
- Generates a temporary README.md with the expected content
- Verifies that the actual README.md contains all necessary example links and descriptions

This change makes the README verification process part of the standard test suite, runnable via `cargo test`. By keeping this verification in Rust rather than bash, we ensure better cross-platform compatibility and integration with the rest of the testing infrastructure.
