### PR TITLE
Fix const path join (1553)

### DIFF
--- a/examples/restriction/const_path_join/tests/ui/const_path_join.rs
+++ b/examples/restriction/const_path_join/tests/ui/const_path_join.rs
@@ -1,0 +1,23 @@
+#![warn(const_path_join)]
+
+use std::path::PathBuf;
+
+fn main() {
+    // Test cases with literal strings
+    let _ = PathBuf::from("foo").join("bar");
+    let _ = PathBuf::from("foo").join("bar").join("baz");
+    let _ = PathBuf::new().join("foo").join("bar");
+
+    // Test cases with constant expressions
+    let _ = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target");
+    let _ = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target").join("debug");
+    
+    // Test cases with mixed literal strings and constant expressions
+    let _ = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src").join("lib.rs");
+    let _ = PathBuf::from("target").join(env!("CARGO_PKG_NAME")).join("debug");
+
+    // Test cases with camino::Utf8PathBuf
+    use camino::Utf8PathBuf;
+    let _ = Utf8PathBuf::from("foo").join("bar");
+    let _ = Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target");
+} 

--- a/examples/restriction/const_path_join/tests/ui/const_path_join.stderr
+++ b/examples/restriction/const_path_join/tests/ui/const_path_join.stderr
@@ -29,7 +29,7 @@ warning: path could be constructed from a string literal
 13 |     let _ = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: use `PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/target"))`
+   = help: use `PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/", "target"))`
 
 warning: path could be constructed from a string literal
   --> const_path_join.rs:14:5
@@ -37,7 +37,7 @@ warning: path could be constructed from a string literal
 14 |     let _ = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target").join("debug");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: use `PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/target/debug"))`
+   = help: use `PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/", "target", "/", "debug"))`
 
 warning: path could be constructed from a string literal
   --> const_path_join.rs:17:5
@@ -45,7 +45,7 @@ warning: path could be constructed from a string literal
 17 |     let _ = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src").join("lib.rs");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: use `PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/src/lib.rs"))`
+   = help: use `PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/", "src", "/", "lib.rs"))`
 
 warning: path could be constructed from a string literal
   --> const_path_join.rs:18:5
@@ -53,7 +53,7 @@ warning: path could be constructed from a string literal
 18 |     let _ = PathBuf::from("target").join(env!("CARGO_PKG_NAME")).join("debug");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: use `PathBuf::from(concat!("target", "/", env!("CARGO_PKG_NAME"), "/debug"))`
+   = help: use `PathBuf::from(concat!("target", "/", env!("CARGO_PKG_NAME"), "/", "debug"))`
 
 warning: path could be constructed from a string literal
   --> const_path_join.rs:22:5
@@ -69,4 +69,4 @@ warning: path could be constructed from a string literal
 23 |     let _ = Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: use `Utf8PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/target"))` 
+   = help: use `Utf8PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/", "target"))` 

--- a/examples/restriction/const_path_join/tests/ui/const_path_join.stderr
+++ b/examples/restriction/const_path_join/tests/ui/const_path_join.stderr
@@ -1,0 +1,72 @@
+warning: path could be constructed from a string literal
+  --> const_path_join.rs:8:5
+   |
+8  |     let _ = PathBuf::from("foo").join("bar");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(const_path_join)]` on by default
+   = help: use `PathBuf::from("foo/bar")`
+
+warning: path could be constructed from a string literal
+  --> const_path_join.rs:9:5
+   |
+9  |     let _ = PathBuf::from("foo").join("bar").join("baz");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use `PathBuf::from("foo/bar/baz")`
+
+warning: path could be constructed from a string literal
+  --> const_path_join.rs:10:5
+   |
+10 |     let _ = PathBuf::new().join("foo").join("bar");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use `.join("foo/bar")`
+
+warning: path could be constructed from a string literal
+  --> const_path_join.rs:13:5
+   |
+13 |     let _ = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use `PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/target"))`
+
+warning: path could be constructed from a string literal
+  --> const_path_join.rs:14:5
+   |
+14 |     let _ = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target").join("debug");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use `PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/target/debug"))`
+
+warning: path could be constructed from a string literal
+  --> const_path_join.rs:17:5
+   |
+17 |     let _ = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src").join("lib.rs");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use `PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/src/lib.rs"))`
+
+warning: path could be constructed from a string literal
+  --> const_path_join.rs:18:5
+   |
+18 |     let _ = PathBuf::from("target").join(env!("CARGO_PKG_NAME")).join("debug");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use `PathBuf::from(concat!("target", "/", env!("CARGO_PKG_NAME"), "/debug"))`
+
+warning: path could be constructed from a string literal
+  --> const_path_join.rs:22:5
+   |
+22 |     let _ = Utf8PathBuf::from("foo").join("bar");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use `Utf8PathBuf::from("foo/bar")`
+
+warning: path could be constructed from a string literal
+  --> const_path_join.rs:23:5
+   |
+23 |     let _ = Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use `Utf8PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/target"))` 


### PR DESCRIPTION
# Fix const_path_join to handle constant expressions

This PR addresses issue #1553 by extending the `const_path_join` lint to handle constant expressions in path components, particularly `env!()` macro expressions.

## Changes
- Modified `collect_components` to properly handle constant expressions
- Added support for `concat!` macro when joining paths with constant expressions
- Fixed path separator handling in string concatenation
- Added comprehensive test cases


Fixes #1553