### PR TITLE
Improve Revs Performance by Avoiding Repeated Tree Checkouts and Adding Version Indexing

### DIFF
--- a/dylint/src/package_options/mod.rs
+++ b/dylint/src/package_options/mod.rs
@@ -1,21 +1,19 @@
 use crate::opts;
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{ Context, Result, anyhow, bail };
 use dylint_internal::{
     clippy_utils::{
-        clippy_utils_version_from_rust_version, set_clippy_utils_dependency_revision,
-        set_toolchain_channel, toolchain_channel,
+        clippy_utils_version_from_rust_version,
+        set_clippy_utils_dependency_revision,
+        set_toolchain_channel,
+        toolchain_channel,
     },
     find_and_replace,
     packaging::new_template,
 };
-use heck::{ToKebabCase, ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase};
+use heck::{ ToKebabCase, ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase };
 use if_chain::if_chain;
 use rewriter::Backup;
-use std::{
-    env::current_dir,
-    fs::{copy, create_dir_all},
-    path::Path,
-};
+use std::{ env::current_dir, fs::{ copy, create_dir_all }, path::Path };
 use tempfile::tempdir;
 use walkdir::WalkDir;
 
@@ -42,18 +40,14 @@ pub fn new_package(_opts: &opts::Dylint, new_opts: &opts::New) -> Result<()> {
 
     // smoelius: Isolation is now the default.
     if !new_opts.isolate {
-        find_and_replace(
-            &tempdir.path().join("Cargo.toml"),
-            r"\r?\n\[workspace\]\r?\n",
-            "",
-        )?;
+        find_and_replace(&tempdir.path().join("Cargo.toml"), r"\r?\n\[workspace\]\r?\n", "")?;
     }
 
     // smoelius: So is allowing unused extern crates.
     find_and_replace(
         &tempdir.path().join("src/lib.rs"),
         r"(?m)^.. (#!\[warn\(unused_extern_crates\)\])$",
-        "${1}",
+        "${1}"
     )?;
 
     fill_in(&name, tempdir.path(), path)?;
@@ -83,9 +77,7 @@ fn fill_in(name: &str, from: &Path, to: &Path) -> Result<()> {
 
         let from_path = from.join(rel_path);
         let to_path = to.join(rel_path);
-        let parent = to_path
-            .parent()
-            .ok_or_else(|| anyhow!("Could not get parent directory"))?;
+        let parent = to_path.parent().ok_or_else(|| anyhow!("Could not get parent directory"))?;
         create_dir_all(parent).with_context(|| {
             format!("`create_dir_all` failed for `{}`", parent.to_string_lossy())
         })?;
@@ -111,27 +103,22 @@ pub fn upgrade_package(opts: &opts::Dylint, upgrade_opts: &opts::Upgrade) -> Res
 
     let rev = {
         let revs = Revs::new(opts.quiet)?;
-        let mut iter = revs.iter()?;
         match &upgrade_opts.rust_version {
             Some(rust_version) => {
                 let clippy_utils_version = clippy_utils_version_from_rust_version(rust_version)?;
-                // smoelius: The next iterative search is a bottleneck. It should be a binary
-                // search.
-                iter.find(|result| {
-                    result
-                        .as_ref()
-                        .map_or(true, |rev| rev.version == clippy_utils_version)
-                })
-                .unwrap_or_else(|| {
-                    Err(anyhow!(
-                        "Could not find `clippy_utils` version `{}`",
-                        clippy_utils_version
-                    ))
-                })?
+                (*revs
+                    .find_version(&clippy_utils_version)?
+                    .ok_or_else(||
+                        anyhow!("Could not find `clippy_utils` version `{}`", clippy_utils_version)
+                    )?).clone()
             }
-            None => iter.next().unwrap_or_else(|| {
-                Err(anyhow!("Could not determine latest `clippy_utils` version"))
-            })?,
+            None =>
+                revs
+                    .iter()?
+                    .next()
+                    .unwrap_or_else(|| {
+                        Err(anyhow!("Could not determine latest `clippy_utils` version"))
+                    })?,
         }
     };
 
@@ -150,15 +137,17 @@ pub fn upgrade_package(opts: &opts::Dylint, upgrade_opts: &opts::Upgrade) -> Res
                 rev.channel
             );
         }
-    };
+    }
 
     let rust_toolchain_path = path.join("rust-toolchain");
     let cargo_toml_path = path.join("Cargo.toml");
 
-    let mut rust_toolchain_backup =
-        Backup::new(rust_toolchain_path).with_context(|| "Could not backup `rust-toolchain`")?;
-    let mut cargo_toml_backup =
-        Backup::new(cargo_toml_path).with_context(|| "Could not backup `Cargo.toml`")?;
+    let mut rust_toolchain_backup = Backup::new(rust_toolchain_path).with_context(
+        || "Could not backup `rust-toolchain`"
+    )?;
+    let mut cargo_toml_backup = Backup::new(cargo_toml_path).with_context(
+        || "Could not backup `Cargo.toml`"
+    )?;
 
     set_toolchain_channel(path, &rev.channel)?;
     set_clippy_utils_dependency_revision(path, &rev.oid.to_string())?;
@@ -167,12 +156,8 @@ pub fn upgrade_package(opts: &opts::Dylint, upgrade_opts: &opts::Upgrade) -> Res
         auto_correct(opts, upgrade_opts, &old_channel, rev.oid)?;
     }
 
-    cargo_toml_backup
-        .disable()
-        .with_context(|| "Could not disable `rust-toolchain` backup")?;
-    rust_toolchain_backup
-        .disable()
-        .with_context(|| "Could not disable `Cargo.toml` backup")?;
+    cargo_toml_backup.disable().with_context(|| "Could not disable `rust-toolchain` backup")?;
+    rust_toolchain_backup.disable().with_context(|| "Could not disable `Cargo.toml` backup")?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR solves #1559 by refactoring the `Revs` implementation to improve performance by:

- Pre-building an index of `Rev` structs from commit trees.
- Eliminating repeated `checkout_tree` calls.
- Using binary search for efficient `find_version` lookups.
- Supporting iteration over a cached, sorted list of versions.