### PR TITLE
Add `dylint_internal::testing::cargo_dylint`

### DIFF
--- a/examples/general/Cargo.lock
+++ b/examples/general/Cargo.lock
@@ -180,20 +180,6 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cargo_metadata"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
@@ -276,7 +262,6 @@ name = "crate_wide_allow"
 version = "4.1.0"
 dependencies = [
  "assert_cmd",
- "cargo_metadata 0.18.1",
  "clippy_utils",
  "dylint_internal",
  "dylint_linting",
@@ -292,6 +277,16 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -371,7 +366,7 @@ version = "4.1.0"
 dependencies = [
  "ansi_term",
  "anyhow",
- "cargo_metadata 0.19.2",
+ "cargo_metadata",
  "dylint_internal",
  "log",
  "once_cell",
@@ -389,7 +384,9 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "bitflags",
- "cargo_metadata 0.19.2",
+ "cargo_metadata",
+ "ctor",
+ "env_logger",
  "git2",
  "home",
  "if_chain",
@@ -406,7 +403,7 @@ dependencies = [
 name = "dylint_linting"
 version = "4.1.0"
 dependencies = [
- "cargo_metadata 0.19.2",
+ "cargo_metadata",
  "dylint_internal",
  "paste",
  "rustversion",
@@ -420,7 +417,7 @@ name = "dylint_testing"
 version = "4.1.0"
 dependencies = [
  "anyhow",
- "cargo_metadata 0.19.2",
+ "cargo_metadata",
  "compiletest_rs",
  "dylint",
  "dylint_internal",

--- a/examples/general/crate_wide_allow/Cargo.toml
+++ b/examples/general/crate_wide_allow/Cargo.toml
@@ -20,10 +20,9 @@ dylint_linting = { path = "../../../utils/linting" }
 
 [target.'cfg(not(no_dev_dependencies))'.dev-dependencies]
 assert_cmd = "2.0"
-cargo_metadata = "0.18"
 predicates = "3.1"
 
-dylint_internal = { path = "../../../internal" }
+dylint_internal = { path = "../../../internal", features = ["testing"] }
 dylint_testing = { path = "../../../utils/testing" }
 
 [features]

--- a/internal/src/cargo.rs
+++ b/internal/src/cargo.rs
@@ -41,7 +41,7 @@ impl From<bool> for Quiet {
 
 /// A `cargo` command builder
 ///
-/// Note that [`std::process::Command`]is itself a builder. So technically that makes this a
+/// Note that [`std::process::Command`] is itself a builder. So technically that makes this a
 /// "builder builder".
 pub struct Builder {
     subcommand: String,

--- a/internal/src/testing.rs
+++ b/internal/src/testing.rs
@@ -1,5 +1,10 @@
+use crate::CommandExt;
 use anyhow::Result;
-use std::path::Path;
+use cargo_metadata::MetadataCommand;
+use std::{
+    env::consts,
+    path::{Path, PathBuf},
+};
 
 #[ctor::ctor]
 fn init() {
@@ -10,4 +15,33 @@ pub fn new_template(path: &Path) -> Result<()> {
     crate::packaging::new_template(path)?;
     crate::packaging::use_local_packages(path)?;
     Ok(())
+}
+
+/// Debug-builds `cargo-dylint` and returns a path to the resulting executable
+///
+/// Arguments
+///
+/// - `workspace_root`: path to workspace root
+///
+/// To run the executable from a test, the likely easiest way is to pass
+/// `--path <PATH_TO_LIBRARY_PACKAGE>` or `--lib-path <PATH_TO_DYNAMIC_LIBRARY>`.
+pub fn cargo_dylint(workspace_root: impl AsRef<Path>) -> Result<PathBuf> {
+    let mut command = crate::cargo::build("`cargo-dylint`").build();
+    command
+        .current_dir(&workspace_root)
+        .args(["--bin", "cargo-dylint"])
+        .success()?;
+
+    let metadata = MetadataCommand::new()
+        .current_dir(workspace_root.as_ref())
+        .no_deps()
+        .exec()
+        .unwrap();
+    let cargo_dylint = metadata
+        .target_directory
+        .as_std_path()
+        .join("debug")
+        .join(format!("cargo-dylint{}", consts::EXE_SUFFIX));
+
+    Ok(cargo_dylint)
 }


### PR DESCRIPTION
From the doc comment:
```rs
/// Debug-builds `cargo-dylint` and returns a path to the resulting executable
///
/// Arguments
///
/// - `workspace_root`: path to workspace root
///
/// To run the executable from a test, the likely easiest way is to pass
/// `--path <PATH_TO_LIBRARY_PACKAGE>` or `--lib-path <PATH_TO_DYNAMIC_LIBRARY>`.
```