### PR TITLE
Fix: Don't trigger lint for std::fmt::Result return types

### DIFF
--- a/examples/general/non_local_effect_before_error_return/src/lib.rs
+++ b/examples/general/non_local_effect_before_error_return/src/lib.rs
@@ -150,7 +150,7 @@ impl<'tcx> LateLintPass<'tcx> for NonLocalEffectBeforeErrorReturn {
             return;
         }
 
-        if !is_result(cx, cx.typeck_results().expr_ty(body.value)) {
+        if !is_lintable_result(cx, cx.typeck_results().expr_ty(body.value)) {
             return;
         }
 
@@ -221,9 +221,21 @@ fn in_async_function(tcx: ty::TyCtxt<'_>, hir_id: rustc_hir::HirId) -> bool {
         })
 }
 
-fn is_result(cx: &LateContext<'_>, ty: ty::Ty) -> bool {
-    if let ty::Adt(adt, _) = ty.kind() {
-        cx.tcx.is_diagnostic_item(sym::Result, adt.did())
+fn is_lintable_result(cx: &LateContext<'_>, ty: ty::Ty) -> bool {
+    if let ty::Adt(adt, substs) = ty.kind() {
+        if !cx.tcx.is_diagnostic_item(sym::Result, adt.did()) {
+            return false;
+        }
+
+        // Don't lint if the error type is core::fmt::Error
+        if let Some(error_ty) = substs.get(1)
+            && let ty::Adt(error_adt, _) = error_ty.expect_ty().kind()
+            && match_def_path(cx, error_adt.did(), &["core", "fmt", "Error"])
+        {
+            return false;
+        }
+
+        true
     } else {
         false
     }

--- a/examples/general/non_local_effect_before_error_return/ui/main.rs
+++ b/examples/general/non_local_effect_before_error_return/ui/main.rs
@@ -276,3 +276,15 @@ pub mod public_only {
         Err(VarError::NotPresent)
     }
 }
+
+// Test to check that functions returning std::fmt::Result should not trigger the lint
+pub mod fmt_result_test {
+    use std::fmt::{self, Write};
+
+    pub fn fmt_result_with_write_before_err_return(buffer: &mut String) -> fmt::Result {
+        // This non-local effect (write) should not trigger a lint warning
+        // because the return type is std::fmt::Result
+        buffer.write_str("Hello, world!")?;
+        Err(fmt::Error)
+    }
+}

--- a/examples/general/non_local_effect_before_error_return/ui/main.stderr
+++ b/examples/general/non_local_effect_before_error_return/ui/main.stderr
@@ -155,12 +155,6 @@ warning: assignment to dereference before error return
 LL |         *flag = true;
    |         ^^^^^^^^^^^^
 
-warning: call to `std::fmt::DebugStruct::<'_, '_>::field` with mutable reference before error return
-  --> $DIR/main.rs:260:12
-   |
-LL | pub struct Foo {
-   |            ^^^
-
 warning: call to `std::vec::Vec::<u32>::push` with mutable reference before error return
   --> $DIR/main.rs:270:12
    |
@@ -173,5 +167,5 @@ note: error is determined here
 LL |         Err(VarError::NotPresent)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: 16 warnings emitted
+warning: 15 warnings emitted
 

--- a/examples/general/non_local_effect_before_error_return/ui_public_only/main.rs
+++ b/examples/general/non_local_effect_before_error_return/ui_public_only/main.rs
@@ -276,3 +276,15 @@ pub mod public_only {
         Err(VarError::NotPresent)
     }
 }
+
+// Test to check that functions returning std::fmt::Result should not trigger the lint
+pub mod fmt_result_test {
+    use std::fmt::{self, Write};
+
+    pub fn fmt_result_with_write_before_err_return(buffer: &mut String) -> fmt::Result {
+        // This non-local effect (write) should not trigger a lint warning
+        // because the return type is std::fmt::Result
+        buffer.write_str("Hello, world!")?;
+        Err(fmt::Error)
+    }
+}

--- a/examples/general/non_local_effect_before_error_return/ui_public_only/main.stderr
+++ b/examples/general/non_local_effect_before_error_return/ui_public_only/main.stderr
@@ -155,12 +155,6 @@ warning: assignment to dereference before error return
 LL |         *flag = true;
    |         ^^^^^^^^^^^^
 
-warning: call to `std::fmt::DebugStruct::<'_, '_>::field` with mutable reference before error return
-  --> $DIR/main.rs:260:12
-   |
-LL | pub struct Foo {
-   |            ^^^
-
 warning: call to `std::vec::Vec::<u32>::push` with mutable reference before error return
   --> $DIR/main.rs:270:12
    |
@@ -185,5 +179,5 @@ note: error is determined here
 LL |         Err(VarError::NotPresent)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: 17 warnings emitted
+warning: 16 warnings emitted
 


### PR DESCRIPTION
## Description

This PR addresses issue #929 by preventing the `non_local_effect_before_error_return` lint from firing in functions that return `std::fmt::Result`.

### Problem

The lint was previously triggering warnings for functions returning `std::fmt::Result`, but as noted in the issue, these reports tend to be uninteresting and add unnecessary noise to the lint output.

### Changes

1. Renamed the `is_result` function to `is_lintable_result` to better reflect its purpose
2. Enhanced the function to check if the second generic argument of `Result` is `core::fmt::Error`
3. If the error type is `core::fmt::Error`, the function now returns `false`, preventing the lint from being applied
4. Added test cases in both `ui/main.rs` and `ui_public_only/main.rs` to verify the behavior

### Implementation Details

The implementation follows the approach suggested in the issue:
- Access the generic arguments (`substs`) in the Result type
- Check the second argument (index 1) using `clippy_utils::match_def_path` to determine if it's `core::fmt::Error`
- Return `false` in this case to skip applying the lint

### Testing

Added test functions returning `fmt::Result` with non-local effects before returning an error to verify the fix. The tests pass with no warnings being emitted for these functions, confirming the lint no longer fires for `std::fmt::Result` return types.

Fixes #929