### PR TITLE
Skip CHANGELOG.md in markdown link check to avoid GitHub rate limits

### DIFF
--- a/cargo-dylint/tests/ci.rs
+++ b/cargo-dylint/tests/ci.rs
@@ -817,4 +817,3 @@ fn dirty(ignore_blank_lines: bool) -> Option<String> {
         Some(String::from_utf8(output.stdout).unwrap())
     }
 }
-

--- a/cargo-dylint/tests/ci.rs
+++ b/cargo-dylint/tests/ci.rs
@@ -565,6 +565,11 @@ fn markdown_link_check() {
         let entry = entry.unwrap();
         let path = entry.path();
 
+        // Skip CHANGELOG.md to avoid hitting GitHub rate limits
+        if path.file_name() == Some(OsStr::new("CHANGELOG.md")) {
+            continue;
+        }
+
         let path_buf = Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join(path);
 
         let assert = Command::new("npx")
@@ -812,3 +817,4 @@ fn dirty(ignore_blank_lines: bool) -> Option<String> {
         Some(String::from_utf8(output.stdout).unwrap())
     }
 }
+


### PR DESCRIPTION
Removed the Changelog link test from the markdown_link_check ci test as mentioned in #1604 
I tested it locally and the test passed locally