### PR TITLE
Enhance wrong_serialize_struct_arg lint to cover more Serde serialization methods

### DIFF
--- a/examples/general/wrong_serialize_struct_arg/README.md
+++ b/examples/general/wrong_serialize_struct_arg/README.md
@@ -2,35 +2,53 @@
 
 ### What it does
 
-Checks for `serialize_struct` calls whose `len` argument does not match the number of
-subsequent `serialize_field` calls.
+Checks for Serde serialization method calls whose `len` argument does not match the number of
+subsequent `serialize_field` or `serialize_element` calls. This includes:
+
+- `serialize_struct` (expects `serialize_field`)
+- `serialize_struct_variant` (expects `serialize_field`)
+- `serialize_tuple_struct` (expects `serialize_field`)
+- `serialize_tuple_variant` (expects `serialize_field`)
+- `serialize_tuple` (expects `serialize_element`)
 
 ### Why is this bad?
 
 The [`serde` documentation] is unclear on whether the `len` argument is meant to be a hint.
 Even if it is just a hint, there's no telling what real-world implementations will do with
 that argument. Thus, ensuring that the argument is correct helps protect against
-`SerializeStruct` implementations that expect it to be correct, even if such implementations
-are only hypothetical.
+implementations that expect it to be correct, even if such implementations are only hypothetical.
 
-### Example
+### Examples
 
 ```rust
-let mut state = serializer.serialize_struct("Color", 1)?; // `len` is 1
+let mut state = serializer.serialize_struct("Color", 1)?; // `len` is 1, but 3 fields follow
 state.serialize_field("r", &self.r)?;
 state.serialize_field("g", &self.g)?;
 state.serialize_field("b", &self.b)?;
 state.end()
+
+let mut tup = serializer.serialize_tuple(1)?; // `len` is 1, but 2 elements follow
+tup.serialize_element(&self.0)?;
+tup.serialize_element(&self.1)?;
+tup.end()
 ```
 
 Use instead:
 
 ```rust
-let mut state = serializer.serialize_struct("Color", 3)?; // `len` is 3
+let mut state = serializer.serialize_struct("Color", 3)?;
 state.serialize_field("r", &self.r)?;
 state.serialize_field("g", &self.g)?;
 state.serialize_field("b", &self.b)?;
 state.end()
+
+let mut tup = serializer.serialize_tuple(2)?;
+tup.serialize_element(&self.0)?;
+tup.serialize_element(&self.1)?;
+tup.end()
 ```
+
+The same principle applies to other serialization methods like `serialize_struct_variant`,
+`serialize_tuple_struct`, and `serialize_tuple_variant`.
 
 [`serde` documentation]: https://docs.rs/serde/latest/serde/trait.Serializer.html#tymethod.serialize_struct

--- a/examples/general/wrong_serialize_struct_arg/ui/main.rs
+++ b/examples/general/wrong_serialize_struct_arg/ui/main.rs
@@ -183,3 +183,133 @@ mod wrong_serialize_struct {
         }
     }
 }
+
+mod test_struct_variant {
+    use super::*;
+    use serde::ser::SerializeStructVariant;
+
+    enum ColorEnum {
+        RGB { r: u8, g: u8, b: u8 },
+    }
+
+    impl Serialize for ColorEnum {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            match self {
+                ColorEnum::RGB { r, g, b } => {
+                    let mut state = serializer.serialize_struct_variant(
+                        "ColorEnum",
+                        0,
+                        "RGB",
+                        1, // Wrong length, should be 3
+                    )?;
+                    state.serialize_field("r", r)?;
+                    state.serialize_field("g", g)?;
+                    state.serialize_field("b", b)?;
+                    state.end()
+                }
+            }
+        }
+    }
+}
+
+mod test_tuple_struct {
+    use super::*;
+    use serde::ser::SerializeTupleStruct;
+
+    struct RGB(u8, u8, u8);
+
+    impl Serialize for RGB {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let mut state = serializer.serialize_tuple_struct("RGB", 1)?; // Wrong length, should be 3
+            state.serialize_field(&self.0)?;
+            state.serialize_field(&self.1)?;
+            state.serialize_field(&self.2)?;
+            state.end()
+        }
+    }
+}
+
+mod test_tuple_variant {
+    use super::*;
+    use serde::ser::SerializeTupleVariant;
+
+    enum ColorEnum {
+        RGB(u8, u8, u8),
+    }
+
+    impl Serialize for ColorEnum {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            match self {
+                ColorEnum::RGB(r, g, b) => {
+                    let mut state = serializer.serialize_tuple_variant(
+                        "ColorEnum",
+                        0,
+                        "RGB",
+                        1, // Wrong length, should be 3
+                    )?;
+                    state.serialize_field(r)?;
+                    state.serialize_field(g)?;
+                    state.serialize_field(b)?;
+                    state.end()
+                }
+            }
+        }
+    }
+}
+
+mod test_serialize_tuple {
+    use super::*;
+    use serde::ser::SerializeTuple;
+
+    // Example: A simple 2-tuple
+    struct MyPair(u8, String);
+
+    impl Serialize for MyPair {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            // Incorrect len: 1, but there are 2 elements
+            let mut tup = serializer.serialize_tuple(1)?;
+            tup.serialize_element(&self.0)?;
+            tup.serialize_element(&self.1)?;
+            tup.end()
+        }
+    }
+
+    // Example: Tuple with no elements, but len is specified as 1
+    struct EmptyTupleMarker;
+    impl Serialize for EmptyTupleMarker {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let tup = serializer.serialize_tuple(1)?; // Incorrect len: 1, but 0 elements
+            tup.end()
+        }
+    }
+
+    // Example: Correct usage for a 3-tuple (should not warn)
+    struct MyTriplet(u8, u8, u8);
+    impl Serialize for MyTriplet {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let mut tup = serializer.serialize_tuple(3)?;
+            tup.serialize_element(&self.0)?;
+            tup.serialize_element(&self.1)?;
+            tup.serialize_element(&self.2)?;
+            tup.end()
+        }
+    }
+}

--- a/examples/general/wrong_serialize_struct_arg/ui/main.stderr
+++ b/examples/general/wrong_serialize_struct_arg/ui/main.stderr
@@ -93,5 +93,106 @@ note: `serialize_field` call 1 of 1
 LL |             state.serialize_field("field", &self.field)?;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: 7 warnings emitted
+warning: `serialize_struct_variant` call's `len` argument is 1, but number of `serialize_field` calls is 3
+  --> $DIR/main.rs:202:37
+   |
+LL |                       let mut state = serializer.serialize_struct_variant(
+   |  _____________________________________^
+LL | |                         "ColorEnum",
+LL | |                         0,
+LL | |                         "RGB",
+LL | |                         1, // Wrong length, should be 3
+LL | |                     )?;
+   | |_____________________^
+   |
+note: `serialize_field` call 1 of 3
+  --> $DIR/main.rs:208:21
+   |
+LL |                     state.serialize_field("r", r)?;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: `serialize_field` call 2 of 3
+  --> $DIR/main.rs:209:21
+   |
+LL |                     state.serialize_field("g", g)?;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: `serialize_field` call 3 of 3
+  --> $DIR/main.rs:210:21
+   |
+LL |                     state.serialize_field("b", b)?;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: `serialize_tuple_struct` call's `len` argument is 1, but number of `serialize_field` calls is 3
+  --> $DIR/main.rs:229:29
+   |
+LL |             let mut state = serializer.serialize_tuple_struct("RGB", 1)?; // Wrong length, should be 3
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: `serialize_field` call 1 of 3
+  --> $DIR/main.rs:230:13
+   |
+LL |             state.serialize_field(&self.0)?;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: `serialize_field` call 2 of 3
+  --> $DIR/main.rs:231:13
+   |
+LL |             state.serialize_field(&self.1)?;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: `serialize_field` call 3 of 3
+  --> $DIR/main.rs:232:13
+   |
+LL |             state.serialize_field(&self.2)?;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: `serialize_tuple_variant` call's `len` argument is 1, but number of `serialize_field` calls is 3
+  --> $DIR/main.rs:253:37
+   |
+LL |                       let mut state = serializer.serialize_tuple_variant(
+   |  _____________________________________^
+LL | |                         "ColorEnum",
+LL | |                         0,
+LL | |                         "RGB",
+LL | |                         1, // Wrong length, should be 3
+LL | |                     )?;
+   | |_____________________^
+   |
+note: `serialize_field` call 1 of 3
+  --> $DIR/main.rs:259:21
+   |
+LL |                     state.serialize_field(r)?;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^
+note: `serialize_field` call 2 of 3
+  --> $DIR/main.rs:260:21
+   |
+LL |                     state.serialize_field(g)?;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^
+note: `serialize_field` call 3 of 3
+  --> $DIR/main.rs:261:21
+   |
+LL |                     state.serialize_field(b)?;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: `serialize_tuple` call's `len` argument is 1, but number of `serialize_element` calls is 2
+  --> $DIR/main.rs:282:27
+   |
+LL |             let mut tup = serializer.serialize_tuple(1)?;
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: `serialize_element` call 1 of 2
+  --> $DIR/main.rs:283:13
+   |
+LL |             tup.serialize_element(&self.0)?;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: `serialize_element` call 2 of 2
+  --> $DIR/main.rs:284:13
+   |
+LL |             tup.serialize_element(&self.1)?;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: `serialize_tuple` call's `len` argument is 1, but number of `serialize_element` calls is 0
+  --> $DIR/main.rs:296:23
+   |
+LL |             let tup = serializer.serialize_tuple(1)?; // Incorrect len: 1, but 0 elements
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: 12 warnings emitted
 

--- a/internal/src/paths.rs
+++ b/internal/src/paths.rs
@@ -10,8 +10,25 @@ pub const CAMINO_UTF8_PATH_BUF: [&str; 2] = ["camino", "Utf8PathBuf"];
 pub const CELL_REF_CELL: [&str; 3] = ["core", "cell", "RefCell"];
 pub const REF_CELL_BORROW_MUT: [&str; 4] = ["core", "cell", "RefCell", "borrow_mut"];
 
+pub const SERDE_SERIALIZE_FIELD_STRUCT: [&str; 4] =
+    ["serde", "ser", "SerializeStruct", "serialize_field"];
+pub const SERDE_SERIALIZE_FIELD_STRUCT_VARIANT: [&str; 4] =
+    ["serde", "ser", "SerializeStructVariant", "serialize_field"];
+pub const SERDE_SERIALIZE_FIELD_TUPLE_STRUCT: [&str; 4] =
+    ["serde", "ser", "SerializeTupleStruct", "serialize_field"];
+pub const SERDE_SERIALIZE_FIELD_TUPLE_VARIANT: [&str; 4] =
+    ["serde", "ser", "SerializeTupleVariant", "serialize_field"];
+pub const SERDE_SERIALIZE_ELEMENT: [&str; 4] =
+    ["serde", "ser", "SerializeTuple", "serialize_element"];
+
 pub const SERDE_SERIALIZE_STRUCT: [&str; 4] = ["serde", "ser", "Serializer", "serialize_struct"];
-pub const SERDE_SERIALIZE_FIELD: [&str; 4] = ["serde", "ser", "SerializeStruct", "serialize_field"];
+pub const SERDE_SERIALIZE_STRUCT_VARIANT: [&str; 4] =
+    ["serde", "ser", "Serializer", "serialize_struct_variant"];
+pub const SERDE_SERIALIZE_TUPLE: [&str; 4] = ["serde", "ser", "Serializer", "serialize_tuple"];
+pub const SERDE_SERIALIZE_TUPLE_STRUCT: [&str; 4] =
+    ["serde", "ser", "Serializer", "serialize_tuple_struct"];
+pub const SERDE_SERIALIZE_TUPLE_VARIANT: [&str; 4] =
+    ["serde", "ser", "Serializer", "serialize_tuple_variant"];
 
 pub const ENV_REMOVE_VAR: [&str; 3] = ["std", "env", "remove_var"];
 pub const ENV_SET_CURRENT_DIR: [&str; 3] = ["std", "env", "set_current_dir"];


### PR DESCRIPTION
This PR addresses #850 which basically enhances the `wrong_serialize_struct_arg` lint to apply to more Serde serialization functions.

#### Key Changes:
The following Serde Serializer methods, in addition to the original serialize_struct are supported now:

- [serialize_struct_variant](https://docs.rs/serde/latest/serde/trait.Serializer.html#tymethod.serialize_struct_variant)
- [serialize_tuple](https://docs.rs/serde/latest/serde/trait.Serializer.html#tymethod.serialize_tuple)
- [serialize_tuple_struct](https://docs.rs/serde/latest/serde/trait.Serializer.html#tymethod.serialize_tuple_struct)
- [serialize_tuple_variant](https://docs.rs/serde/latest/serde/trait.Serializer.html#tymethod.serialize_tuple_variant)
