### PR TITLE
Add: Converted `lint` test from workflow and added to rust rest

### DIFF
--- a/cargo-dylint/tests/ci.rs
+++ b/cargo-dylint/tests/ci.rs
@@ -728,7 +728,7 @@ fn lint_script_test() {
                 if entry.path().is_dir() {
                     let lib_name = entry.file_name().into_string().unwrap();
                     // Exclude overscoped_allow as in the script
-                    if lib_name != "overscoped_allow" {
+                    if lib_name != "overscoped_allow" && lib_name != ".cargo" {
                         restriction_libs.push(format!("--lib {lib_name}"));
                     }
                 }

--- a/cargo-dylint/tests/ci.rs
+++ b/cargo-dylint/tests/ci.rs
@@ -728,6 +728,9 @@ fn lint() {
     }
     let restrictions_as_flags = restriction_libs.join(" ");
 
+    let base_flags =
+        format!("--lib general --lib supplementary {restrictions_as_flags} --lib clippy");
+
     let mut dirs_to_lint: Vec<PathBuf> = [
         ".",
         "driver",
@@ -749,9 +752,6 @@ fn lint() {
         }
     }
 
-    let base_flags =
-        format!("--lib general --lib supplementary {restrictions_as_flags} --lib clippy");
-
     for dir_path in &dirs_to_lint {
         eprintln!("Linting in directory: {dir_path:?}");
 
@@ -765,9 +765,6 @@ fn lint() {
 
         let status = cmd.status().expect("Failed to execute command");
 
-        if !status.success() {
-            eprintln!("Failed to lint in {dir_path:?}");
-        }
         assert!(status.success(), "Linting failed in {dir_path:?}");
     }
 }

--- a/cargo-dylint/tests/ci.rs
+++ b/cargo-dylint/tests/ci.rs
@@ -22,6 +22,8 @@ static METADATA: LazyLock<Metadata> = LazyLock::new(|| current_metadata().unwrap
 static DESCRIPTION_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"description\s*=\s*"([^"]*)""#).unwrap());
 
+const DYLINT_RUSTFLAGS_VAR_NAME: &str = "DYLINT_RUSTFLAGS";
+
 #[ctor::ctor]
 fn initialize() {
     set_current_dir("..").unwrap();
@@ -747,10 +749,8 @@ fn lint_script_test() {
             }
         }
 
-        let base_flags = format!(
-            "--lib general --lib supplementary {} --lib clippy",
-            restrictions_as_flags
-        );
+        let base_flags =
+            format!("--lib general --lib supplementary {restrictions_as_flags} --lib clippy");
 
         let mut dirs_to_lint = vec![
             ".",
@@ -773,26 +773,25 @@ fn lint_script_test() {
         if target_dir.exists() {
             for entry in walkdir::WalkDir::new(&target_dir) {
                 let entry = entry.unwrap();
-                if entry.file_name().to_string_lossy() == ".fingerprint" {
-                    if entry
+                if entry.file_name().to_string_lossy() == ".fingerprint"
+                    && (entry
                         .path()
                         .starts_with(target_dir.join("dylint/target/nightly-"))
-                        || entry.path().starts_with(target_dir.join("nightly-"))
-                    {
-                        let _ = remove_dir_all(entry.path());
-                    }
+                        || entry.path().starts_with(target_dir.join("nightly-")))
+                {
+                    let _ = remove_dir_all(entry.path());
                 }
             }
         }
 
-        set_var("DYLINT_RUSTFLAGS", "-D warnings");
-        eprintln!("DYLINT_RUSTFLAGS='-D warnings'");
+        set_var(DYLINT_RUSTFLAGS_VAR_NAME, "-D warnings");
+        eprintln!("{DYLINT_RUSTFLAGS_VAR_NAME}='-D warnings'");
 
         for dir_path_str in &dirs_to_lint {
             let dir_path = Path::new(dir_path_str);
-            eprintln!("Linting in directory: {:?}", dir_path);
+            eprintln!("Linting in directory: {dir_path:?}");
 
-            let mut cmd = Command::new(&cargo_dylint_path);
+            let mut cmd = Command::new(cargo_dylint_path);
             cmd.arg("dylint");
             cmd.args(base_flags.split_whitespace());
             cmd.args(["--", "--all-features", "--tests", "--workspace"]);
@@ -802,11 +801,11 @@ fn lint_script_test() {
             let output = cmd.output().expect("Failed to execute command");
 
             if !output.status.success() {
-                eprintln!("Failed to lint in {:?}", dir_path);
+                eprintln!("Failed to lint in {dir_path:?}");
                 eprintln!("Stdout: {}", String::from_utf8_lossy(&output.stdout));
                 eprintln!("Stderr: {}", String::from_utf8_lossy(&output.stderr));
             }
-            assert!(output.status.success(), "Linting failed in {:?}", dir_path);
+            assert!(output.status.success(), "Linting failed in {dir_path:?}");
         }
     });
 }

--- a/cargo-dylint/tests/ci.rs
+++ b/cargo-dylint/tests/ci.rs
@@ -718,7 +718,9 @@ fn update() {
 #[test]
 fn lint_script_test() {
     preserves_cleanliness("lint_script_test", false, || {
-        let cargo_dylint_path = Path::new("target/debug/cargo-dylint");
+        let cargo_dylint_path = Path::new("target/debug/cargo-dylint")
+            .canonicalize()
+            .expect("Failed to find cargo-dylint executable. Ensure it is built, e.g., with `cargo build -p cargo-dylint`.");
 
         let example_restriction_dir = Path::new("examples/restriction");
         let mut restriction_libs = Vec::new();
@@ -791,7 +793,7 @@ fn lint_script_test() {
             let dir_path = Path::new(dir_path_str);
             eprintln!("Linting in directory: {dir_path:?}");
 
-            let mut cmd = Command::new(cargo_dylint_path);
+            let mut cmd = Command::new(&cargo_dylint_path);
             cmd.arg("dylint");
             cmd.args(base_flags.split_whitespace());
             cmd.args(["--", "--all-features", "--tests", "--workspace"]);

--- a/cargo-dylint/tests/ci.rs
+++ b/cargo-dylint/tests/ci.rs
@@ -11,7 +11,7 @@ use std::{
     env::{set_current_dir, set_var, var},
     ffi::OsStr,
     fmt::Write as _,
-    fs::{read_dir, read_to_string, write},
+    fs::{read_dir, read_to_string, remove_dir_all, write},
     io::{Write as _, stderr},
     path::{Component, Path},
     sync::{LazyLock, Mutex},
@@ -709,6 +709,104 @@ fn update() {
                 ])
                 .assert()
                 .success();
+        }
+    });
+}
+
+#[test]
+fn lint_script_test() {
+    preserves_cleanliness("lint_script_test", false, || {
+        let cargo_dylint_path = Path::new("target/debug/cargo-dylint");
+
+        let example_restriction_dir = Path::new("examples/restriction");
+        let mut restriction_libs = Vec::new();
+        if example_restriction_dir.is_dir() {
+            for entry in read_dir(example_restriction_dir).unwrap() {
+                let entry = entry.unwrap();
+                if entry.path().is_dir() {
+                    let lib_name = entry.file_name().into_string().unwrap();
+                    // Exclude overscoped_allow as in the script
+                    if lib_name != "overscoped_allow" {
+                        restriction_libs.push(format!("--lib {lib_name}"));
+                    }
+                }
+            }
+        }
+        let restrictions_as_flags = restriction_libs.join(" ");
+
+        let mut experimental_dirs_str = Vec::new();
+        let example_experimental_dir = Path::new("examples/experimental");
+        if example_experimental_dir.is_dir() {
+            for entry in read_dir(example_experimental_dir).unwrap() {
+                let entry = entry.unwrap();
+                let path = entry.path();
+                if path.is_dir() && path.file_name().unwrap() != ".cargo" {
+                    // Convert path to string for the DIRS array
+                    experimental_dirs_str.push(path.to_string_lossy().to_string());
+                }
+            }
+        }
+
+        let base_flags = format!(
+            "--lib general --lib supplementary {} --lib clippy",
+            restrictions_as_flags
+        );
+
+        let mut dirs_to_lint = vec![
+            ".",
+            "driver",
+            "utils/linting",
+            "examples/general",
+            "examples/supplementary",
+            "examples/restriction",
+            "examples/testing/clippy",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect::<Vec<_>>();
+
+        dirs_to_lint.extend(experimental_dirs_str);
+
+        // Function similar to force_check in lint.sh
+        let workspace_root = Path::new("."); // current dir is workspace root
+        let target_dir = workspace_root.join("target");
+        if target_dir.exists() {
+            for entry in walkdir::WalkDir::new(&target_dir) {
+                let entry = entry.unwrap();
+                if entry.file_name().to_string_lossy() == ".fingerprint" {
+                    if entry
+                        .path()
+                        .starts_with(target_dir.join("dylint/target/nightly-"))
+                        || entry.path().starts_with(target_dir.join("nightly-"))
+                    {
+                        let _ = remove_dir_all(entry.path());
+                    }
+                }
+            }
+        }
+
+        set_var("DYLINT_RUSTFLAGS", "-D warnings");
+        eprintln!("DYLINT_RUSTFLAGS='-D warnings'");
+
+        for dir_path_str in &dirs_to_lint {
+            let dir_path = Path::new(dir_path_str);
+            eprintln!("Linting in directory: {:?}", dir_path);
+
+            let mut cmd = Command::new(&cargo_dylint_path);
+            cmd.arg("dylint");
+            cmd.args(base_flags.split_whitespace());
+            cmd.args(["--", "--all-features", "--tests", "--workspace"]);
+            cmd.current_dir(dir_path);
+
+            // Capture output for debugging if needed
+            let output = cmd.output().expect("Failed to execute command");
+
+            if !output.status.success() {
+                eprintln!("Failed to lint in {:?}", dir_path);
+                eprintln!("Stdout: {}", String::from_utf8_lossy(&output.stdout));
+                eprintln!("Stderr: {}", String::from_utf8_lossy(&output.stderr));
+            }
+            assert!(output.status.success(), "Linting failed in {:?}", dir_path);
         }
     });
 }


### PR DESCRIPTION
This PR solves #636 and introduces a new integration test `lint_script_test` to ensure that linting remains clean across various directories. The test replicates the functionality of the existing `lint.sh` script using Rust.


* Automates the execution of `cargo-dylint` across:

  * `examples/general`
  * `examples/supplementary`
  * `examples/restriction` (excluding `overscoped_allow`)
  * `examples/testing/clippy`
  * Dynamically detected `examples/experimental` subdirectories
* Sets `DYLINT_RUSTFLAGS` to `-D warnings` to ensure strict linting
* Cleans up old `.fingerprint` directories under nightly targets to force fresh lint runs
* Asserts success of each lint command and logs output for debugging upon failure

Fixes #636 