### PR TITLE
Fix Typos in Comments for Clarity

### DIFF
--- a/dylint-link/src/main.rs
+++ b/dylint-link/src/main.rs
@@ -130,7 +130,7 @@ fn extract_out_path_from_linker_response_file(path: impl AsRef<Path>) -> Result<
     File::open(path)?.read_to_end(&mut buf)?;
 
     // MinerSebas: Convert the File from UTF-16 to a Rust UTF-8 String
-    // (Only necessary for MSVC, the GNU Linker uses UTF-8 isntead.)
+    // (Only necessary for MSVC, the GNU Linker uses UTF-8 instead.)
     // Based on: https://stackoverflow.com/a/57172592
     let file: Vec<u16> = buf
         .chunks_exact(2)

--- a/internal/src/command.rs
+++ b/internal/src/command.rs
@@ -58,7 +58,7 @@ pub fn driver(toolchain: &str, driver: &Path) -> Result<Command> {
     let mut command = Command::new(driver);
     #[cfg(windows)]
     {
-        // MinerSebas: To succesfully determine the dylint driver Version on Windows,
+        // MinerSebas: To successfully determine the dylint driver Version on Windows,
         // it is neccesary to add some Libraries to the Path.
         let new_path = prepend_toolchain_path(toolchain)?;
         command.envs(vec![(crate::env::PATH, new_path)]);


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in comments within the codebase to improve clarity and readability. Specifically, it fixes the spelling of "instead" and "successfully" in comments in `dylint-link/src/main.rs` and `internal/src/command.rs`. No functional code changes are included; only comment text has been updated.
