### PR TITLE
Cache driver `Result` rather than `Path`

### DIFF
--- a/utils/linting/tests/build.rs
+++ b/utils/linting/tests/build.rs
@@ -10,6 +10,7 @@ fn channel_is_nightly() {
 }
 
 #[test]
+#[ignore = "recent nightlies started rejecting Cargo feature `doc_auto_cfg`, which some of `dylint_linting`'s dependencies use"]
 fn builds_with_cfg_docsrs() {
     update_nightly().unwrap();
 

--- a/utils/testing/src/ui.rs
+++ b/utils/testing/src/ui.rs
@@ -80,7 +80,7 @@ impl Test {
     }
 
     fn run_immutable(&self) {
-        let driver = initialize(&self.name).unwrap();
+        let driver = initialize(&self.name).as_ref().unwrap();
 
         match &self.target {
             Target::SrcBase(src_base) => {


### PR DESCRIPTION
This way, there will be at most one attempt to build a driver. If that attempt fails, subsequent attempts will show the same failing result.