### PR TITLE
Bump MSRV

### DIFF
--- a/dylint/Cargo.toml
+++ b/dylint/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/trailofbits/dylint"
 # This should match `dylint_internal::msrv::MSRV`.
-rust-version = "1.88"
+rust-version = "1.91"
 
 [dependencies]
 anstyle = { workspace = true }

--- a/expensive/tests/boundary_toolchains.rs
+++ b/expensive/tests/boundary_toolchains.rs
@@ -21,10 +21,11 @@ const BOUNDARIES: &[(&str, &str)] = &[
     // https://github.com/rust-lang/rust/pull/153778
     // https://github.com/rust-lang/rust/commit/44c87292ac (rollup merge 2026-03-18)
     ("nightly-2026-03-18", "nightly-2026-03-19"),
-    // https://github.com/rust-lang/rust/pull/138682
-    // https://github.com/rust-lang/rust/commit/0abc6c6e9859bc6915ddc76d484117ff626481c6
-    // smoelius: 2025-05-15 is skipped because there is no release for that date.
-    ("nightly-2025-05-14", "nightly-2025-05-16"),
+    // smoelius: `cargo-platform@0.3.3` requires rustc 1.91.
+    // // https://github.com/rust-lang/rust/pull/138682
+    // // https://github.com/rust-lang/rust/commit/0abc6c6e9859bc6915ddc76d484117ff626481c6
+    // // smoelius: 2025-05-15 is skipped because there is no release for that date.
+    // ("nightly-2025-05-14", "nightly-2025-05-16"),
     // smoelius: `libloading-0.9.0` requires rustc 1.88.
     // https://github.com/rust-lang/rust/pull/135880
     // https://github.com/rust-lang/rust/commit/7d31ae7f351b4aa0fcb47d1d22e04c275bef0653

--- a/internal/src/msrv.rs
+++ b/internal/src/msrv.rs
@@ -20,23 +20,24 @@
 // smoelius: Edition 2024 was stabilized with Rust 1.85.
 // smoelius: `zmij v1.0.1` requires Rust 1.88. However, `zmij`'s build script considers
 // nightly-2025-04-22 Rust 1.88. Hence, the MSRV must be bumped to 1.89.
-pub const MSRV: &str = "1.89.0";
+// smoelius: `cargo-platform@0.3.3` requires rustc 1.91.
+pub const MSRV: &str = "1.91.0";
 
 /// The channel Clippy was using when it switched to 0.[`MSRV`].
 ///
 /// Note that this is not the channel when Rust switched to [`MSRV`].
-pub const MSRV_CHANNEL: &str = "nightly-2025-05-14";
+pub const MSRV_CHANNEL: &str = "nightly-2025-08-07";
 
 /// The `clippy_utils` Git OID (commit hash) for [`MSRV`].
-pub const MSRV_CLIPPY_UTILS_REV: &str = "93bd4d893122417b9265563c037f11a158a8e37c";
+pub const MSRV_CLIPPY_UTILS_REV: &str = "334fb906aef13d20050987b13448f37391bb97a2";
 
 /// The minimum supported Rust version plus one minor version.
-pub const MSRV_PLUS_1: &str = "1.90.0";
+pub const MSRV_PLUS_1: &str = "1.92.0";
 
 /// The channel Clippy was using when it switched to 0.[`MSRV_PLUS_1`].
 ///
 /// Note that this is not the channel when Rust switched to [`MSRV_PLUS_1`].
-pub const MSRV_PLUS_1_CHANNEL: &str = "nightly-2025-07-10";
+pub const MSRV_PLUS_1_CHANNEL: &str = "nightly-2025-09-18";
 
 /// The `clippy_utils` Git OID (commit hash) for [`MSRV_PLUS_1`].
-pub const MSRV_PLUS_1_CLIPPY_UTILS_REV: &str = "4e614bf683fb265079f79268408cd69e361efdcc";
+pub const MSRV_PLUS_1_CLIPPY_UTILS_REV: &str = "20ce69b9a63bcd2756cd906fe0964d1e901e042a";


### PR DESCRIPTION
`cargo-platform@0.3.3` requires rustc 1.91.