### PR TITLE
[ci] Build Linux release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,63 @@ on:
       - "v*"
 
 jobs:
+  build-binaries:
+    name: Build binaries (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build binaries
+        run: cargo build --locked --release --target ${{ matrix.target }} -p cargo-dylint -p dylint-link
+
+      - name: Package binaries
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="${GITHUB_REF_NAME#v}"
+          BINARIES="cargo-dylint dylint-link"
+
+          for BINARY in $BINARIES; do
+            PACKAGE_NAME="${BINARY}-${{ matrix.target }}-v${VERSION}"
+            mkdir -p "${PACKAGE_NAME}"
+            cp "target/${{ matrix.target }}/release/${BINARY}" "${PACKAGE_NAME}/"
+
+            ARCHIVE="${PACKAGE_NAME}.tar.gz"
+            tar -czf "${ARCHIVE}" "${PACKAGE_NAME}"
+            sha256sum "${ARCHIVE}" > "${ARCHIVE}.sha256"
+          done
+
+      - name: Upload binary artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: binaries-${{ matrix.target }}
+          path: |
+            cargo-dylint-${{ matrix.target }}-v*.tar.gz
+            cargo-dylint-${{ matrix.target }}-v*.tar.gz.sha256
+            dylint-link-${{ matrix.target }}-v*.tar.gz
+            dylint-link-${{ matrix.target }}-v*.tar.gz.sha256
+          if-no-files-found: error
+
   publish:
+    needs: build-binaries
     runs-on: ubuntu-latest
     permissions:
+      actions: read
+      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v6
@@ -21,12 +75,48 @@ jobs:
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
 
+      - name: Download binary artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: rsign2
+          fallback: cargo-install
+
+      - name: Sign binary artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          MANIFESTS="cargo-dylint/Cargo.toml dylint-link/Cargo.toml"
+          trap 'rm -f minisign.key minisign.pub' EXIT
+
+          rsign generate -f -W -p minisign.pub -s minisign.key
+          echo "::add-mask::$(tail -n 1 minisign.key)"
+
+          PUBLIC_KEY="$(tail -n 1 minisign.pub)"
+
+          for MANIFEST in $MANIFESTS; do
+            printf '\n[package.metadata.binstall.signing]\n' >> "${MANIFEST}"
+            printf 'algorithm = "minisign"\n' >> "${MANIFEST}"
+            printf 'pubkey = "%s"\n' "${PUBLIC_KEY}" >> "${MANIFEST}"
+          done
+
+          for ARCHIVE in dist/*.tar.gz; do
+            rsign sign -W -s minisign.key -x "${ARCHIVE}.sig" "${ARCHIVE}"
+          done
+
       - name: Publish
         run: |
+          set -euo pipefail
+
           # smoelius: Publishing in this order ensures that all dependencies are met.
           DIRS="internal driver dylint-link dylint cargo-dylint utils/linting utils/testing"
           for DIR in $DIRS; do
-              pushd "$DIR" && (cargo publish || true) && popd
+              cargo publish --allow-dirty --manifest-path "$DIR/Cargo.toml"
           done
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
@@ -44,6 +134,10 @@ jobs:
           tag_name: ${{ github.ref }}
           name: Release ${{ steps.get-version.outputs.version }}
           body_path: body.md
+          files: |
+            dist/*.tar.gz
+            dist/*.sha256
+            dist/*.sig
           draft: false
           prerelease: ${{ contains(github.ref, 'pre') || contains(github.ref, 'rc') }}
           token: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
## Overview

Adds a step to the release workflow to build, sign, and publish the `cargo-dylint` and `dylint-link` binaries.

### Signing

The signing step uses the [`JIT Signing strategy`](https://github.com/cargo-bins/cargo-binstall/blob/bbd0a7de0e936c8c626fa0e93584169d58ff1307/SIGNING.md#just-in-time-signing) described in the `cargo-binstall` docs, creating an ephemeral key and signing each binary before uploading.

`cargo-binstall` will verify the `*.sig` files against the public key included in the crate's manifest for the given version, which is injected prior to publishing the crates.

closes #1971 