### PR TITLE
dylint-link: inject `-flavor link` when wrapping rust-lld on Windows

### DIFF
--- a/dylint-link/src/main.rs
+++ b/dylint-link/src/main.rs
@@ -23,7 +23,20 @@ fn main() -> Result<()> {
 
     let linker = linker()?;
     let args: Vec<String> = args().collect();
-    Command::new(linker).args(&args[1..]).success()?;
+
+    let mut command = Command::new(&linker);
+    // `rust-lld` and `lld` are generic LLD drivers: they need to be told which
+    // flavor (ELF / Mach-O / COFF / Wasm) to act as. When configured as the
+    // linker on Windows-MSVC they expect to be invoked as `lld-link`, which can
+    // be achieved either via a same-named symlink or by passing `-flavor link`
+    // ahead of the linker arguments. Inject the flag here so that
+    // `linker = "rust-lld"` in Cargo's configuration file works without further
+    // setup.
+    #[cfg(target_os = "windows")]
+    if needs_lld_link_flavor(&linker) {
+        command.args(["-flavor", "link"]);
+    }
+    command.args(&args[1..]).success()?;
 
     if let Some(path) = output_path(args.iter())? {
         copy_library(&path)?;
@@ -82,6 +95,14 @@ fn default_linker() -> Result<PathBuf> {
 #[allow(clippy::unnecessary_wraps)]
 fn default_linker() -> Result<PathBuf> {
     Ok(PathBuf::from("cc"))
+}
+
+#[cfg(target_os = "windows")]
+fn needs_lld_link_flavor(linker: &Path) -> bool {
+    let Some(stem) = linker.file_stem().and_then(OsStr::to_str) else {
+        return false;
+    };
+    stem.eq_ignore_ascii_case("rust-lld") || stem.eq_ignore_ascii_case("lld")
 }
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Summary

`dylint-link` invokes the configured linker directly without replicating rustc's flavor-handling for the bundled LLD. When a user has `linker = "rust-lld.exe"` (or `"lld.exe"`) configured in `~/.cargo/config.toml` for an `*-windows-msvc` target — a common setup on Windows-MSVC hosts that don't have Visual Studio installed — `dylint-link` ends up running:

```
rust-lld.exe /NOLOGO <object files> ... /OUT:...
```

`rust-lld.exe` is a generic LLD driver and errors out:

> lld is a generic driver. Invoke ld.lld (Unix), ld64.lld (macOS), lld-link (Windows), wasm-ld (WebAssembly) instead

rustc avoids this by prepending `-flavor link` (or `-flavor wasm`/etc.) when it detects the linker is `rust-lld`. `dylint-link` wraps the linker invocation but loses that step, so dylint can't build any lint crate or transitive build-script on such systems.

## Fix

Detect when the resolved linker stem is `rust-lld` or `lld` on Windows and inject `-flavor link` before forwarding the rest of the arguments. The check is name-based and case-insensitive, matching rustc's heuristic.

## Test plan

- [x] On Windows-MSVC with `linker = "rust-lld.exe"` in `~/.cargo/config.toml`, `cargo dylint --all` now builds and runs lints successfully. Prior to this change, build-scripts of crates like \`serde_core\`, \`anyhow\`, \`proc-macro2\` fail to link.
- [x] No-op on platforms where the resolved linker is not `rust-lld`/`lld` (the `#[cfg(target_os = "windows")]` gate ensures the injection only runs on Windows).
- [x] No-op when MSVC's `link.exe` is the configured linker.