### PR TITLE
fix(release): avoid embedding `dylint-driver` source paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Build binaries
         run: cargo build --locked --release --target ${{ matrix.target }} -p cargo-dylint -p dylint-link
+        env:
+          DYLINT_DRIVER_FROM_CRATES_IO: 1
 
       - name: Package binaries
         shell: bash

--- a/dylint/build.rs
+++ b/dylint/build.rs
@@ -1,12 +1,15 @@
 use dylint_internal::{cargo::cargo_home, env};
 use std::{fs::OpenOptions, io::Write, path::Path};
 
+const DYLINT_DRIVER_FROM_CRATES_IO: &str = "DYLINT_DRIVER_FROM_CRATES_IO";
+
 fn main() {
     write_dylint_driver_manifest_dir();
 
     #[cfg(feature = "__cargo_cli")]
     println!("cargo:rustc-cfg=__library_packages");
 
+    println!("cargo:rerun-if-env-changed={DYLINT_DRIVER_FROM_CRATES_IO}");
     println!("cargo:rerun-if-changed=build.rs");
 }
 
@@ -22,6 +25,7 @@ fn write_dylint_driver_manifest_dir() {
             .parent()
             .is_some_and(|path| path.ends_with("target/package"))
         || env::var(env::DOCS_RS).is_ok()
+        || env::var(DYLINT_DRIVER_FROM_CRATES_IO).is_ok()
     {
         "None".to_owned()
     } else {


### PR DESCRIPTION
## Overview

Detail that was overlooked in #1971: Release builds of `cargo-dylint` currently compile from the repository checkout, so `dylint/build.rs` records the sibling driver directory as an absolute path. `cargo-binstall` users then receive a binary that tries to build `dylint_driver` from the release runner's `/home/runner/work/...` checkout, which does not exist outside that job.

Add an explicit `DYLINT_DRIVER_FROM_CRATES_IO` build-time envvar and set it in the release workflow. Packaged binaries now generate driver crates that depend on `dylint_driver` by version from crates.io, while local workspace builds continue using the sibling driver path for development.