### PR TITLE
Build driver from crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Build binaries
-        run: cargo build --locked --release --target ${{ matrix.target }} -p cargo-dylint -p dylint-link
+        run: cargo build --locked --release --target ${{ matrix.target }} -p cargo-dylint -p dylint-link --features=dylint/__driver_from_crates_io
 
       - name: Package binaries
         shell: bash
@@ -116,6 +116,9 @@ jobs:
           done
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+      - name: Test crates.io driver
+        run: cargo test -p dylint --features=__driver_from_crates_io driver_from_crates_io -- --ignored --nocapture
 
       - name: Get version
         id: get-version

--- a/dylint/Cargo.toml
+++ b/dylint/Cargo.toml
@@ -84,6 +84,7 @@ __cargo_cli = [
     "toml",
     "url",
 ]
+__driver_from_crates_io = []
 
 [lints]
 workspace = true

--- a/dylint/build.rs
+++ b/dylint/build.rs
@@ -17,7 +17,8 @@ fn write_dylint_driver_manifest_dir() {
     #[cfg_attr(dylint_lib = "general", allow(abs_home_path))]
     let dylint_manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
 
-    let dylint_driver_manifest_dir = if dylint_manifest_dir.starts_with(cargo_home)
+    let dylint_driver_manifest_dir = if cfg!(feature = "__driver_from_crates_io")
+        || dylint_manifest_dir.starts_with(cargo_home)
         || dylint_manifest_dir
             .parent()
             .is_some_and(|path| path.ends_with("target/package"))

--- a/dylint/src/driver_builder.rs
+++ b/dylint/src/driver_builder.rs
@@ -245,6 +245,7 @@ mod test {
 
     // smoelius: `tempdir` is a temporary directory. So there should be no race here.
     #[cfg_attr(dylint_lib = "general", allow(non_thread_safe_call_in_test))]
+    #[cfg(not(feature = "__driver_from_crates_io"))]
     #[test]
     fn nightly() {
         let tempdir = tempdir().unwrap();
@@ -257,7 +258,7 @@ mod test {
     // smoelius: This test passes on macOS but for the wrong reason. On recent macOS versions (e.g.,
     // Tahoe), if you copy `/bin/sleep` to you local directory and run it, it will be killed, even
     // without `child.kill()`. I haven't yet figured out how best to address this.
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(all(not(feature = "__driver_from_crates_io"), not(target_os = "macos")))]
     #[test]
     fn can_install_while_driver_is_running() {
         use std::process::{Command, ExitStatus};
@@ -286,5 +287,45 @@ mod test {
 
         child.kill().unwrap();
         let _: ExitStatus = child.wait().unwrap();
+    }
+
+    // smoelius: The `driver_from_crates_io` test is disabled for normal CI. Run it locally with the
+    // following command:
+    // ```
+    // cargo test -p dylint --features=__driver_from_crates_io driver_from_crates_io -- --ignored --nocapture
+    // ```
+    #[cfg_attr(dylint_lib = "general", allow(non_thread_safe_call_in_test))]
+    #[cfg(feature = "__driver_from_crates_io")]
+    #[ignore = "requires current `dylint_driver` version to be published"]
+    #[test]
+    fn driver_from_crates_io() {
+        use std::fs::read_to_string;
+
+        let tempdir = tempdir().unwrap();
+        initialize("nightly", tempdir.path()).unwrap();
+
+        let contents = read_to_string(tempdir.path().join("Cargo.toml")).unwrap();
+        let dependency = contents
+            .lines()
+            .find(|line| line.starts_with("dylint_driver = "))
+            .unwrap();
+        assert_eq!(
+            concat!(
+                "dylint_driver = { version = \"=",
+                env!("CARGO_PKG_VERSION"),
+                "\" }"
+            ),
+            dependency
+        );
+
+        build(&opts::Dylint::default(), "nightly", tempdir.path()).unwrap();
+        assert!(
+            !is_outdated(
+                &opts::Dylint::default(),
+                "nightly",
+                &tempdir.path().join("dylint-driver")
+            )
+            .unwrap()
+        );
     }
 }


### PR DESCRIPTION
Alternative to #1985 that uses a Cargo feature instead of an environment variable. The PR also adds a test.