### PR TITLE
fix: ignore explicitly typed variables in misleading_variable_name

### DIFF
--- a/examples/restriction/misleading_variable_name/README.md
+++ b/examples/restriction/misleading_variable_name/README.md
@@ -2,8 +2,9 @@
 
 ### What it does
 
-Checks for variables satisfying the following three conditions:
+Checks for variables satisfying the following four conditions:
 
+- The variable is declared without an explicit type.
 - The variable is initialized with the result of a function call.
 - The variable's name matches the name of a type defined within the module in which the
   function is defined.

--- a/examples/restriction/misleading_variable_name/src/lib.rs
+++ b/examples/restriction/misleading_variable_name/src/lib.rs
@@ -20,8 +20,9 @@ use std::collections::BTreeMap;
 dylint_linting::declare_late_lint! {
     /// ### What it does
     ///
-    /// Checks for variables satisfying the following three conditions:
+    /// Checks for variables satisfying the following four conditions:
     ///
+    /// - The variable is declared without an explicit type.
     /// - The variable is initialized with the result of a function call.
     /// - The variable's name matches the name of a type defined within the module in which the
     ///   function is defined.
@@ -60,6 +61,7 @@ impl<'tcx> LateLintPass<'tcx> for MisleadingVariableName {
                         kind: PatKind::Binding(_, _, ident, _),
                         ..
                     },
+                ty: None,
                 init: Some(init),
                 ..
             }) = stmt.kind

--- a/examples/restriction/misleading_variable_name/ui/main.rs
+++ b/examples/restriction/misleading_variable_name/ui/main.rs
@@ -64,6 +64,8 @@ fn main() -> Result<()> {
     // negative tests
     let contents = read_to_string(path).unwrap();
 
+    let file: String = read_to_string(path).unwrap();
+
     let lines = Cursor::new([]).lines();
 
     let bar = private::foo();


### PR DESCRIPTION
Fixes #1903.

## Summary

- skip `misleading_variable_name` for let bindings with an explicit type annotation
- add a UI regression case proving an explicitly typed binding stays quiet
- document the new fourth condition and regenerate the checked-in example README

## Verification

I locally verified the complete amended diff:

- Before the fix, the explicit `String` binding produced a seventh warning and failed the UI fixture. After the fix, the standalone UI test passes while the six existing warning expectations remain unchanged.
- `PATH="$PWD/target/debug:$PATH" CARGO_TARGET_DIR="$PWD/target" cargo +nightly-2026-05-28 test --manifest-path examples/restriction/misleading_variable_name/Cargo.toml` — 1 UI test passed
- `cargo test -p cargo-dylint --test ci format_example_readmes` — 1 README consistency test passed
- `cargo +nightly-2026-05-28 fmt --all --check`
- `git diff --check`

## Assistance disclosure

OpenAI Codex helped inspect the maintainer feedback and execute the local checks. I reviewed the code change, generated README, diff, and verification output before pushing.