### PR TITLE
Invalidate rustc's incremental cache when the set of registered lints changes

### DIFF
--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -21,6 +21,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
+mod untracked_state;
+use untracked_state::{UNTRACKED_STATE_VAR, UNTRACKED_STATE_VARS, hash_from_env};
+
 pub const DYLINT_VERSION: &str = "0.1.0";
 
 type DylintVersionFunc = unsafe fn() -> *mut std::os::raw::c_char;
@@ -298,24 +301,19 @@ impl rustc_driver::Callbacks for Callbacks {
                 previous(sess, lint_store);
             }
 
-            let dylint_libs = env::var(env::DYLINT_LIBS).ok();
-            let dylint_metadata = env::var(env::DYLINT_METADATA).ok();
             let dylint_no_deps = env::var(env::DYLINT_NO_DEPS).ok();
             let dylint_no_deps_enabled = dylint_no_deps.as_ref().is_some_and(|value| value != "0");
             let cargo_primary_package_is_set = env::var(env::CARGO_PRIMARY_PACKAGE).is_ok();
 
-            sess.env_depinfo().lock().insert((
-                rustc_span::Symbol::intern(env::DYLINT_LIBS),
-                dylint_libs.as_deref().map(rustc_span::Symbol::intern),
-            ));
-            sess.env_depinfo().lock().insert((
-                rustc_span::Symbol::intern(env::DYLINT_METADATA),
-                dylint_metadata.as_deref().map(rustc_span::Symbol::intern),
-            ));
-            sess.env_depinfo().lock().insert((
-                rustc_span::Symbol::intern(env::DYLINT_NO_DEPS),
-                dylint_no_deps.as_deref().map(rustc_span::Symbol::intern),
-            ));
+            // This loop and `untracked_state::hash_from_env` are fed from the same list. See
+            // `UNTRACKED_STATE_VARS` for why a variable missing from either one is a bug.
+            for var in UNTRACKED_STATE_VARS {
+                let value = env::var(var).ok();
+                sess.env_depinfo().lock().insert((
+                    rustc_span::Symbol::intern(var),
+                    value.as_deref().map(rustc_span::Symbol::intern),
+                ));
+            }
 
             if dylint_no_deps_enabled && !cargo_primary_package_is_set {
                 return;
@@ -409,8 +407,15 @@ pub fn run<T: AsRef<OsStr>>(args: &[T]) -> Result<()> {
     let sysroot = sysroot().ok();
     let rustflags = rustflags();
     let paths = paths();
+    let untracked_state = hash_from_env(&paths)?;
 
-    let rustc_args = rustc_args(args, sysroot.as_deref(), &rustflags, &paths)?;
+    let rustc_args = rustc_args(
+        args,
+        sysroot.as_deref(),
+        &rustflags,
+        &paths,
+        untracked_state.as_deref(),
+    )?;
 
     let mut callbacks = Callbacks::new(paths);
 
@@ -449,6 +454,7 @@ fn rustc_args<T: AsRef<OsStr>, U: AsRef<str>, V: AsRef<Path>>(
     sysroot: Option<&Path>,
     rustflags: &[U],
     paths: &[V],
+    untracked_state: Option<&str>,
 ) -> Result<Vec<String>> {
     let mut args = args.iter().peekable();
     let mut rustc_args = Vec::new();
@@ -477,6 +483,18 @@ fn rustc_args<T: AsRef<OsStr>, U: AsRef<str>, V: AsRef<Path>>(
         } else {
             bail!("could not parse `{}`", path.as_ref().to_string_lossy());
         }
+    }
+    if let Some(untracked_state) = untracked_state {
+        rustc_args.extend([
+            // Passing `-Zunstable-options` causes rustc to register its internal lints, which are
+            // deny-by-default and meant for compiler development. Libraries are exactly the crates
+            // that use `rustc_private` and could trip them, so allow the group: asking for
+            // `--env-set` should not change which lints fire. A user can still override this, as
+            // `DYLINT_RUSTFLAGS` is appended after these arguments.
+            "--allow=rustc::internal".to_owned(),
+            "-Zunstable-options".to_owned(),
+            format!("--env-set={UNTRACKED_STATE_VAR}={untracked_state}"),
+        ]);
     }
     rustc_args.extend(args.map(|s| s.as_ref().to_string_lossy().to_string()));
     rustc_args.extend(

--- a/driver/src/tests.rs
+++ b/driver/src/tests.rs
@@ -14,7 +14,8 @@ fn no_rustc() {
             &["--crate-name", "name"],
             None,
             &[] as &[&str],
-            &[] as &[&Path]
+            &[] as &[&Path],
+            None
         )
         .unwrap()
     );
@@ -28,7 +29,8 @@ fn plain_rustc() {
             &["rustc", "--crate-name", "name"],
             None,
             &[] as &[&str],
-            &[] as &[&Path]
+            &[] as &[&Path],
+            None
         )
         .unwrap()
     );
@@ -42,8 +44,107 @@ fn qualified_rustc() {
             &["/bin/rustc", "--crate-name", "name"],
             None,
             &[] as &[&str],
-            &[] as &[&Path]
+            &[] as &[&Path],
+            None
         )
         .unwrap()
     );
+}
+
+#[test]
+fn untracked_state_is_passed_to_rustc() {
+    assert_eq!(
+        vec![
+            "rustc",
+            "--allow=rustc::internal",
+            "-Zunstable-options",
+            "--env-set=DYLINT_UNTRACKED_STATE=0123456789abcdef",
+            "--crate-name",
+            "name"
+        ],
+        rustc_args(
+            &["--crate-name", "name"],
+            None,
+            &[] as &[&str],
+            &[] as &[&Path],
+            Some("0123456789abcdef")
+        )
+        .unwrap()
+    );
+}
+
+#[test]
+fn no_untracked_state_without_libraries() {
+    assert_eq!(None, untracked_state::hash(&[], &[] as &[&Path]).unwrap());
+}
+
+// Rebuilding a library overwrites the same path, so the hash must depend on more than the paths
+// in `DYLINT_LIBS`. The two writes have equal length, so this fails if the hash reflects only
+// the libraries' sizes.
+#[cfg_attr(dylint_lib = "general", allow(non_thread_safe_call_in_test))]
+#[test]
+fn untracked_state_changes_when_library_is_rebuilt() {
+    let path = library_path("rebuilt", "liblibrary@toolchain.so");
+
+    std::fs::write(&path, b"registers lint_a").unwrap();
+    let before = untracked_state::hash(&[], &[&path]).unwrap();
+
+    std::fs::write(&path, b"registers lint_b").unwrap();
+    let after = untracked_state::hash(&[], &[&path]).unwrap();
+
+    assert!(before.is_some());
+    assert_ne!(before, after);
+}
+
+#[cfg_attr(dylint_lib = "general", allow(non_thread_safe_call_in_test))]
+#[test]
+fn untracked_state_is_independent_of_path_order() {
+    let path_a = library_path("order", "liba@toolchain.so");
+    let path_b = library_path("order", "libb@toolchain.so");
+    std::fs::write(&path_a, b"a").unwrap();
+    std::fs::write(&path_b, b"b").unwrap();
+
+    assert_eq!(
+        untracked_state::hash(&[], &[&path_a, &path_b]).unwrap(),
+        untracked_state::hash(&[], &[&path_b, &path_a]).unwrap()
+    );
+}
+
+// `CARGO_PRIMARY_PACKAGE` and `DYLINT_NO_DEPS` together determine whether `Callbacks::config`
+// registers any lints at all, so they must affect the hash.
+#[cfg_attr(dylint_lib = "general", allow(non_thread_safe_call_in_test))]
+#[test]
+fn untracked_state_depends_on_primary_package() {
+    let path = library_path("primary_package", "liblibrary@toolchain.so");
+    std::fs::write(&path, b"contents").unwrap();
+
+    let primary =
+        untracked_state::hash(&[(env::CARGO_PRIMARY_PACKAGE, Some("1"))], &[&path]).unwrap();
+    let not_primary =
+        untracked_state::hash(&[(env::CARGO_PRIMARY_PACKAGE, None)], &[&path]).unwrap();
+
+    assert_ne!(primary, not_primary);
+}
+
+#[cfg_attr(dylint_lib = "general", allow(non_thread_safe_call_in_test))]
+#[test]
+fn untracked_state_depends_on_no_deps() {
+    let path = library_path("no_deps", "liblibrary@toolchain.so");
+    std::fs::write(&path, b"contents").unwrap();
+
+    let with_no_deps =
+        untracked_state::hash(&[(env::DYLINT_NO_DEPS, Some("1"))], &[&path]).unwrap();
+    let without_no_deps =
+        untracked_state::hash(&[(env::DYLINT_NO_DEPS, Some("0"))], &[&path]).unwrap();
+
+    assert_ne!(with_no_deps, without_no_deps);
+}
+
+// `OUT_DIR` is used rather than a temporary directory so that the driver needs no additional
+// dev-dependency. Each test gets its own subdirectory so that the tests do not interfere with
+// one another.
+fn library_path(test: &str, filename: &str) -> PathBuf {
+    let dir = Path::new(concat!(env!("OUT_DIR"), "/untracked_state")).join(test);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.join(filename)
 }

--- a/driver/src/untracked_state.rs
+++ b/driver/src/untracked_state.rs
@@ -1,0 +1,124 @@
+//! Which lints are registered is an input to compilation that rustc's incremental dependency graph
+//! knows nothing about. Writing the variables in [`UNTRACKED_STATE_VARS`] to `sess.env_depinfo`
+//! (see `Callbacks::config`) tells Cargo to re-invoke rustc when the input changes, but it does not
+//! tell rustc to distrust its cache: `env_depinfo` is written to the dep-info file for the build
+//! system to read, and nothing in rustc reads it back. So rustc reloads a cache produced with a
+//! different set of registered lints, sees that everything it recorded as an input to its dep-graph
+//! nodes is unchanged (it marks them "green"), and ICEs when a query such as
+//! `shallow_lint_levels_on` recomputes to a different value anyway. See
+//! <https://github.com/trailofbits/dylint/issues/2010>.
+//!
+//! rustc discards its cache when `Options::dep_tracking_hash` changes, so the fix is to get the
+//! state into that hash. `rustc_interface::Config::track_state` looks like the way to do that, but
+//! its hasher was removed in <https://github.com/rust-lang/rust/pull/155671>. What remains of the
+//! callback can only write to `env_depinfo` and `file_depinfo`, which is the tracking that is
+//! already insufficient.
+//!
+//! `--env-set` reaches the hash instead. Each field of `Options` is declared with a marker saying
+//! whether it participates in `dep_tracking_hash`: `[UNTRACKED]` fields do not, `[TRACKED]` fields
+//! do and also contribute to the crate hash, and `[TRACKED_NO_CRATE_HASH]` fields do only the
+//! former. `--env-set` writes to `logical_env`, which is `[TRACKED]`, so changing its value still
+//! causes rustc to discard its cache:
+//! <https://github.com/rust-lang/rust/blob/78e7c7b9f9f6a671255ff0fb88b5a6fd6dbc7a58/compiler/rustc_session/src/options.rs#L106-L129>
+
+use anyhow::{Context, Result};
+use dylint_internal::env;
+use std::{
+    fs::read,
+    hash::{DefaultHasher, Hasher},
+    path::Path,
+};
+
+/// The environment variable that carries the hash into `logical_env`.
+///
+/// Nothing reads the value back. It is set only so that changing it changes `dep_tracking_hash`.
+pub(crate) const UNTRACKED_STATE_VAR: &str = "DYLINT_UNTRACKED_STATE";
+
+/// The environment variables whose change should cause lints to be rerun.
+///
+/// `CARGO_PRIMARY_PACKAGE` and `DYLINT_NO_DEPS` determine whether lints are registered at all,
+/// `DYLINT_LIBS` names the libraries that register them, and `DYLINT_METADATA` is the metadata from
+/// which those libraries are resolved.
+///
+/// Read by two consumers that must not drift apart: `sess.env_depinfo`, which tells Cargo when to
+/// re-invoke rustc, and [`hash_from_env`], which tells rustc when to discard its incremental cache.
+/// A rerun needs both, since re-invoking rustc accomplishes nothing if rustc then reuses results
+/// computed under the old values.
+pub(crate) const UNTRACKED_STATE_VARS: &[&str] = &[
+    env::CARGO_PRIMARY_PACKAGE,
+    env::DYLINT_LIBS,
+    env::DYLINT_METADATA,
+    env::DYLINT_NO_DEPS,
+];
+
+/// Reads [`UNTRACKED_STATE_VARS`] from the environment and forwards them to [`hash`].
+pub(crate) fn hash_from_env<V: AsRef<Path>>(paths: &[V]) -> Result<Option<String>> {
+    let values = UNTRACKED_STATE_VARS
+        .iter()
+        .map(|var| env::var(var).ok())
+        .collect::<Vec<_>>();
+    let vars = UNTRACKED_STATE_VARS
+        .iter()
+        .zip(&values)
+        .map(|(&var, value)| (var, value.as_deref()))
+        .collect::<Vec<_>>();
+    hash(&vars, paths)
+}
+
+/// Hashes the state whose change should cause lints to be rerun.
+///
+/// `vars` are the values of [`UNTRACKED_STATE_VARS`]. They are passed in rather than read from the
+/// environment so that this function is a function of its arguments alone.
+///
+/// Returns `None` if no libraries are loaded, in which case Dylint registers no lints and there is
+/// no untracked state to account for.
+pub(crate) fn hash<V: AsRef<Path>>(
+    vars: &[(&str, Option<&str>)],
+    paths: &[V],
+) -> Result<Option<String>> {
+    if paths.is_empty() {
+        return Ok(None);
+    }
+
+    // `DefaultHasher` is not guaranteed to produce the same values across Rust versions, but it
+    // does not need to. Two runs are compared only if they used the same driver, because the
+    // toolchain determines both the target directory and which driver is built.
+    let mut hasher = DefaultHasher::new();
+
+    // Distinguish hashes computed by different versions of this function.
+    hasher.write(b"dylint-untracked-state-v1");
+
+    for &(var, value) in vars {
+        hasher.write(var.as_bytes());
+        match value {
+            Some(value) => {
+                hasher.write(b"=");
+                hasher.write(value.as_bytes());
+            }
+            // Distinguish an unset variable from one set to the empty string.
+            None => hasher.write(b"\0"),
+        }
+    }
+
+    // `DYLINT_LIBS` names the libraries but says nothing about their contents, and
+    // `library_filename` derives a library's name from just its lint name and toolchain. So a
+    // rebuilt library overwrites the same path and registers a different set of lints without
+    // changing any of the variables above. Hash the libraries themselves to catch that.
+    //
+    // The contents are a proxy for what actually matters, which is the set of lint names the
+    // libraries register. That set cannot be known here: obtaining it means registering the lints,
+    // which requires a `Session`. But the `Session` is built from the command line on which this
+    // hash is passed, so the hash must be computed first. Candidate proxies form a scale of
+    // sensitivity: the paths alone, then each library's length and mtime, then its full contents.
+    // Prefer the more sensitive end, since an unnecessary change to the hash costs only a needless
+    // recompilation.
+    let mut paths = paths.iter().map(AsRef::as_ref).collect::<Vec<_>>();
+    paths.sort_unstable();
+    for path in paths {
+        let contents =
+            read(path).with_context(|| format!("could not read `{}`", path.to_string_lossy()))?;
+        hasher.write(&contents);
+    }
+
+    Ok(Some(format!("{:016x}", hasher.finish())))
+}

--- a/dylint/src/lib.rs
+++ b/dylint/src/lib.rs
@@ -596,11 +596,6 @@ mod test {
     }
 
     fn name_toolchain_map() -> NameToolchainMap<'static> {
-        // smoelius: See comment regarding `CARGO_INCREMENTAL` in `list` integration test.
-        unsafe {
-            std::env::set_var(env::CARGO_INCREMENTAL, "0");
-        }
-
         NameToolchainMap::new(&OPTS)
     }
 }


### PR DESCRIPTION
Claude-generated fix for #2010. Needs to be reviewed. For example, I think some of the comments can be trimmed.

## Problem

Which lints are registered is an input to compilation that rustc's incremental dependency
graph does not know about. The driver writes `DYLINT_LIBS` to `sess.env_depinfo`, which tells
Cargo to re-invoke rustc when the library set changes, but `env_depinfo` is written to the
dep-info file for the build system to read and nothing in rustc reads it back.

So rustc re-runs, reloads a cache produced with a different set of registered lints, sees that
everything it recorded as an input to those nodes is unchanged, and ICEs when a query whose
result depends on the registered lints recomputes to a different value:

```
error: internal compiler error: encountered incremental compilation error with
       shallow_lint_levels_on(build_script_build[7369])
```

`shallow_lint_levels_on` resolves the names inside `#[allow(...)]` against the lint store, so
whether `clippy::unwrap_used` or a library's own lint is a *known* name depends on which
libraries registered lints. Two runs with different library sets therefore produce different
results for that query from identical source text.

## Change

rustc discards its incremental cache when `Options::dep_tracking_hash` changes, and
`Options::logical_env` is `[TRACKED]`. The driver now hashes the state that determines which
lints are registered and passes it via `--env-set`, so a change to that state invalidates the
cache:

```rust
if let Some(untracked_state) = untracked_state {
    rustc_args.extend([
        "-Zunstable-options".to_owned(),
        format!("--env-set={UNTRACKED_STATE_VAR}={untracked_state}"),
    ]);
}
```

The hash covers `CARGO_PRIMARY_PACKAGE`, `DYLINT_LIBS`, `DYLINT_METADATA`, and `DYLINT_NO_DEPS`
— the variables `Callbacks::config` consults when deciding which lints to register — plus the
contents of each loaded library, since `library_filename` derives a library's name from just its
lint name and toolchain, so a rebuilt library registers a different set of lints at an unchanged
path.

Those variables now live in one `UNTRACKED_STATE_VARS` constant that both `sess.env_depinfo` and
the hash iterate. The two are read by different consumers and a variable missing from either is a
bug: omitting one from `env_depinfo` means lints silently do not re-run, and omitting one from
the hash means an ICE. This adds `CARGO_PRIMARY_PACKAGE` to `env_depinfo`, where it was
previously absent even though `Callbacks::config` reads it.

`untracked_state` returns `None` when no libraries are loaded, so plain rustc invocations are
unaffected.

## Test

`dylint`'s `multiple_libraries_multiple_toolchains` and `multiple_libraries_one_toolchain` run
against the same fixture, and therefore the same target directory, with different library sets.
They were passing only because `name_toolchain_map` set `CARGO_INCREMENTAL=0`. That is removed,
which makes those two tests a regression test for this bug: without the driver change they fail
with `shallow_lint_levels_on` ICEs, and with it they pass.

## Verified

- `cargo test`, `cargo fmt --check`, and `cargo clippy --all-targets -- -D warnings` on `driver`.
- `driver` builds and tests on `nightly-2025-08-07` (`MSRV_CHANNEL`) and builds on
  `nightly-2025-09-18`; `--env-set` is accepted across that range, so no `rustversion` gate is
  needed.
- `cargo dylint` on `driver` with `--all-targets` reports no new lints.
- `cargo dylint list` and the `misleading_variable_name` UI tests are unaffected.
- Directly: with `-C incremental` and `-Zincremental-info`, the driver reports
  `completely ignoring cache because of differing commandline arguments` when the library set or
  `DYLINT_NO_DEPS` changes, and does not report it when they hold constant.

## Notes

- `--env-set` requires `-Zunstable-options`, which the driver now passes. This also widens what
  else rustc accepts on that command line, including from `DYLINT_RUSTFLAGS`.
- `logical_env` is `[TRACKED]` rather than `[TRACKED_NO_CRATE_HASH]`, so the hash also feeds the
  crate hash. Every wrapped crate in a run receives the same value.
- `option_env!("DYLINT_UNTRACKED_STATE")` now resolves in linted code.
- Hashing the libraries costs about 0.1s per compilation unit for a 35 MiB library set, measured
  on a 15-library `--all`.
- The `CARGO_INCREMENTAL=0` in `cargo-dylint/tests/integration/list.rs` is left in place. That one
  is about a target directory shared between two toolchains, which is a different problem.
