### PR TITLE
Extend `assert_eq_arg_misordering` to `vec!` arguments

### DIFF
--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -531,42 +531,42 @@ mod test {
     #[test]
     fn no_rustc() {
         assert_eq!(
+            vec!["rustc", "--crate-name", "name"],
             rustc_args(
                 &["--crate-name", "name"],
                 None,
                 &[] as &[&str],
                 &[] as &[&Path]
             )
-            .unwrap(),
-            vec!["rustc", "--crate-name", "name"]
+            .unwrap()
         );
     }
 
     #[test]
     fn plain_rustc() {
         assert_eq!(
+            vec!["rustc", "--crate-name", "name"],
             rustc_args(
                 &["rustc", "--crate-name", "name"],
                 None,
                 &[] as &[&str],
                 &[] as &[&Path]
             )
-            .unwrap(),
-            vec!["rustc", "--crate-name", "name"]
+            .unwrap()
         );
     }
 
     #[test]
     fn qualified_rustc() {
         assert_eq!(
+            vec!["/bin/rustc", "--crate-name", "name"],
             rustc_args(
                 &["/bin/rustc", "--crate-name", "name"],
                 None,
                 &[] as &[&str],
                 &[] as &[&Path]
             )
-            .unwrap(),
-            vec!["/bin/rustc", "--crate-name", "name"]
+            .unwrap()
         );
     }
 }

--- a/examples/restriction/assert_eq_arg_misordering/README.md
+++ b/examples/restriction/assert_eq_arg_misordering/README.md
@@ -2,8 +2,15 @@
 
 ### What it does
 
-Checks for invocations of `assert_eq!` whose arguments are "non-const, const", which
+Checks for invocations of `assert_eq!` whose arguments are "non-const, const-like", which
 suggests they could be "actual, expected".
+
+An argument is "const-like" if it is const-evaluatable, or if it is a non-empty `vec!`
+invocation whose arguments are const-like. The latter allowance is needed because a `vec!`
+invocation allocates, and is therefore never const-evaluatable, even when its value is
+determined entirely by the source text. An empty `vec!` is excluded because moving one to
+the first position can leave its element type uninferable, e.g., `assert_eq!(x, vec![])`
+compiles but `assert_eq!(vec![], x)` does not.
 
 ### Why is this bad?
 
@@ -13,7 +20,7 @@ is unusual, i.e., the "actual" value.
 ### Known problems
 
 A common source of false positives is "sorted, unsorted" where the check is of the
-sortedness of a collection that is const.
+sortedness of a collection that is const-like.
 
 ### Example
 

--- a/examples/restriction/assert_eq_arg_misordering/src/lib.rs
+++ b/examples/restriction/assert_eq_arg_misordering/src/lib.rs
@@ -6,6 +6,7 @@ extern crate rustc_hir;
 
 use clippy_utils::{
     diagnostics::span_lint_and_sugg,
+    higher::VecArgs,
     macros::{find_assert_eq_args, root_macro_call_first_node},
     source::snippet_opt,
     visitors::is_const_evaluatable,
@@ -17,8 +18,15 @@ use rustc_lint::{LateContext, LateLintPass};
 dylint_linting::declare_late_lint! {
     /// ### What it does
     ///
-    /// Checks for invocations of `assert_eq!` whose arguments are "non-const, const", which
+    /// Checks for invocations of `assert_eq!` whose arguments are "non-const, const-like", which
     /// suggests they could be "actual, expected".
+    ///
+    /// An argument is "const-like" if it is const-evaluatable, or if it is a non-empty `vec!`
+    /// invocation whose arguments are const-like. The latter allowance is needed because a `vec!`
+    /// invocation allocates, and is therefore never const-evaluatable, even when its value is
+    /// determined entirely by the source text. An empty `vec!` is excluded because moving one to
+    /// the first position can leave its element type uninferable, e.g., `assert_eq!(x, vec![])`
+    /// compiles but `assert_eq!(vec![], x)` does not.
     ///
     /// ### Why is this bad?
     ///
@@ -28,7 +36,7 @@ dylint_linting::declare_late_lint! {
     /// ### Known problems
     ///
     /// A common source of false positives is "sorted, unsorted" where the check is of the
-    /// sortedness of a collection that is const.
+    /// sortedness of a collection that is const-like.
     ///
     /// ### Example
     ///
@@ -62,24 +70,45 @@ impl<'tcx> LateLintPass<'tcx> for AssertEqArgMisordering {
         let Some((left, right, _)) = find_assert_eq_args(cx, expr, macro_call.expn) else {
             return;
         };
-        let span_comma = left.span.with_lo(left.span.hi()).with_hi(right.span.lo());
-        let Some(((snippet_left, snippet_comma), snippet_right)) = snippet_opt(cx, left.span)
+        if is_const_like(cx, left) || !is_const_like(cx, right) {
+            return;
+        }
+        // A const-like argument can be macro generated (e.g., `vec![0]`), in which case its span
+        // lies within the macro's definition. Use the call sites so that the spans refer to what
+        // was written.
+        let span_left = left.span.source_callsite();
+        let span_right = right.span.source_callsite();
+        let span_comma = span_left.with_lo(span_left.hi()).with_hi(span_right.lo());
+        let Some(((snippet_left, snippet_comma), snippet_right)) = snippet_opt(cx, span_left)
             .zip(snippet_opt(cx, span_comma))
-            .zip(snippet_opt(cx, right.span))
+            .zip(snippet_opt(cx, span_right))
         else {
             return;
         };
-        if !is_const_evaluatable(cx, left) && is_const_evaluatable(cx, right) {
-            span_lint_and_sugg(
-                cx,
-                ASSERT_EQ_ARG_MISORDERING,
-                left.span.with_hi(right.span.hi()),
-                r#"arguments are "non-const, const", which looks like "actual, expected""#,
-                r#"prefer "expected, actual""#,
-                format!("{snippet_right}{snippet_comma}{snippet_left}"),
-                Applicability::MachineApplicable,
-            );
-        }
+        span_lint_and_sugg(
+            cx,
+            ASSERT_EQ_ARG_MISORDERING,
+            span_left.with_hi(span_right.hi()),
+            r#"arguments are "non-const, const-like", which looks like "actual, expected""#,
+            r#"prefer "expected, actual""#,
+            format!("{snippet_right}{snippet_comma}{snippet_left}"),
+            Applicability::MachineApplicable,
+        );
+    }
+}
+
+/// Returns true if `expr`'s value is determined entirely by the source text, i.e., if `expr` is
+/// const-evaluatable or is a `vec!` invocation whose arguments are const-like.
+fn is_const_like<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> bool {
+    match VecArgs::hir(cx, expr) {
+        // An empty `vec!` says nothing about what is expected, and moving one to the first position
+        // can leave its element type uninferable, e.g., `assert_eq!(x, vec![])` compiles but
+        // `assert_eq!(vec![], x)` does not. This case must be checked before
+        // `is_const_evaluatable`, as `vec![]` expands to a call to the `const fn` `Vec::new`.
+        Some(VecArgs::Vec([])) => false,
+        Some(VecArgs::Vec(elems)) => elems.iter().all(|elem| is_const_like(cx, elem)),
+        Some(VecArgs::Repeat(elem, len)) => is_const_like(cx, elem) && is_const_like(cx, len),
+        None => is_const_evaluatable(cx, expr),
     }
 }
 

--- a/examples/restriction/assert_eq_arg_misordering/ui/main.fixed
+++ b/examples/restriction/assert_eq_arg_misordering/ui/main.fixed
@@ -27,3 +27,31 @@ fn const_const() {
 fn non_const_non_const(x: u32, y: u32) {
     assert_eq!(x, y);
 }
+
+fn non_const_vec(x: Vec<u32>) {
+    assert_eq!(vec![0, 1, 2], x);
+}
+
+fn non_const_vec_repeat(x: Vec<u32>) {
+    assert_eq!(vec![0; 3], x);
+}
+
+// `assert_eq!(vec![], x)` would not compile.
+fn non_const_vec_empty(x: Vec<u32>) {
+    assert_eq!(x, vec![]);
+}
+
+fn non_const_vec_multiline(vec_with_a_really_long_name: Vec<u32>) {
+    assert_eq!(
+        vec![CONST_WITH_A_REALLY_LONG_NAME, CONST_WITH_A_REALLY_LONG_NAME],
+        vec_with_a_really_long_name
+    );
+}
+
+fn non_const_vec_of_non_const(x: Vec<u32>, y: u32) {
+    assert_eq!(x, vec![y]);
+}
+
+fn vec_vec() {
+    assert_eq!(vec![0], vec![1]);
+}

--- a/examples/restriction/assert_eq_arg_misordering/ui/main.fixed
+++ b/examples/restriction/assert_eq_arg_misordering/ui/main.fixed
@@ -20,14 +20,6 @@ fn non_const_const_with_message(x: u32) {
     assert_eq!(0, x, "this is a message (with parens)");
 }
 
-fn const_const() {
-    assert_eq!(0, 0);
-}
-
-fn non_const_non_const(x: u32, y: u32) {
-    assert_eq!(x, y);
-}
-
 fn non_const_vec(x: Vec<u32>) {
     assert_eq!(vec![0, 1, 2], x);
 }
@@ -36,16 +28,26 @@ fn non_const_vec_repeat(x: Vec<u32>) {
     assert_eq!(vec![0; 3], x);
 }
 
-// `assert_eq!(vec![], x)` would not compile.
-fn non_const_vec_empty(x: Vec<u32>) {
-    assert_eq!(x, vec![]);
-}
-
 fn non_const_vec_multiline(vec_with_a_really_long_name: Vec<u32>) {
     assert_eq!(
         vec![CONST_WITH_A_REALLY_LONG_NAME, CONST_WITH_A_REALLY_LONG_NAME],
         vec_with_a_really_long_name
     );
+}
+
+// negative tests
+
+fn const_const() {
+    assert_eq!(0, 0);
+}
+
+fn non_const_non_const(x: u32, y: u32) {
+    assert_eq!(x, y);
+}
+
+// `assert_eq!(vec![], x)` would not compile.
+fn non_const_vec_empty(x: Vec<u32>) {
+    assert_eq!(x, vec![]);
 }
 
 fn non_const_vec_of_non_const(x: Vec<u32>, y: u32) {

--- a/examples/restriction/assert_eq_arg_misordering/ui/main.rs
+++ b/examples/restriction/assert_eq_arg_misordering/ui/main.rs
@@ -27,3 +27,31 @@ fn const_const() {
 fn non_const_non_const(x: u32, y: u32) {
     assert_eq!(x, y);
 }
+
+fn non_const_vec(x: Vec<u32>) {
+    assert_eq!(x, vec![0, 1, 2]);
+}
+
+fn non_const_vec_repeat(x: Vec<u32>) {
+    assert_eq!(x, vec![0; 3]);
+}
+
+// `assert_eq!(vec![], x)` would not compile.
+fn non_const_vec_empty(x: Vec<u32>) {
+    assert_eq!(x, vec![]);
+}
+
+fn non_const_vec_multiline(vec_with_a_really_long_name: Vec<u32>) {
+    assert_eq!(
+        vec_with_a_really_long_name,
+        vec![CONST_WITH_A_REALLY_LONG_NAME, CONST_WITH_A_REALLY_LONG_NAME]
+    );
+}
+
+fn non_const_vec_of_non_const(x: Vec<u32>, y: u32) {
+    assert_eq!(x, vec![y]);
+}
+
+fn vec_vec() {
+    assert_eq!(vec![0], vec![1]);
+}

--- a/examples/restriction/assert_eq_arg_misordering/ui/main.rs
+++ b/examples/restriction/assert_eq_arg_misordering/ui/main.rs
@@ -20,14 +20,6 @@ fn non_const_const_with_message(x: u32) {
     assert_eq!(x, 0, "this is a message (with parens)");
 }
 
-fn const_const() {
-    assert_eq!(0, 0);
-}
-
-fn non_const_non_const(x: u32, y: u32) {
-    assert_eq!(x, y);
-}
-
 fn non_const_vec(x: Vec<u32>) {
     assert_eq!(x, vec![0, 1, 2]);
 }
@@ -36,16 +28,26 @@ fn non_const_vec_repeat(x: Vec<u32>) {
     assert_eq!(x, vec![0; 3]);
 }
 
-// `assert_eq!(vec![], x)` would not compile.
-fn non_const_vec_empty(x: Vec<u32>) {
-    assert_eq!(x, vec![]);
-}
-
 fn non_const_vec_multiline(vec_with_a_really_long_name: Vec<u32>) {
     assert_eq!(
         vec_with_a_really_long_name,
         vec![CONST_WITH_A_REALLY_LONG_NAME, CONST_WITH_A_REALLY_LONG_NAME]
     );
+}
+
+// negative tests
+
+fn const_const() {
+    assert_eq!(0, 0);
+}
+
+fn non_const_non_const(x: u32, y: u32) {
+    assert_eq!(x, y);
+}
+
+// `assert_eq!(vec![], x)` would not compile.
+fn non_const_vec_empty(x: Vec<u32>) {
+    assert_eq!(x, vec![]);
 }
 
 fn non_const_vec_of_non_const(x: Vec<u32>, y: u32) {

--- a/examples/restriction/assert_eq_arg_misordering/ui/main.stderr
+++ b/examples/restriction/assert_eq_arg_misordering/ui/main.stderr
@@ -1,4 +1,4 @@
-warning: arguments are "non-const, const", which looks like "actual, expected"
+warning: arguments are "non-const, const-like", which looks like "actual, expected"
   --> $DIR/main.rs:9:16
    |
 LL |     assert_eq!(x, 0);
@@ -6,7 +6,7 @@ LL |     assert_eq!(x, 0);
    |
    = note: `#[warn(assert_eq_arg_misordering)]` on by default
 
-warning: arguments are "non-const, const", which looks like "actual, expected"
+warning: arguments are "non-const, const-like", which looks like "actual, expected"
   --> $DIR/main.rs:14:9
    |
 LL | /         variable_with_a_really_long_name,
@@ -19,11 +19,36 @@ LL ~         CONST_WITH_A_REALLY_LONG_NAME,
 LL +         variable_with_a_really_long_name
    |
 
-warning: arguments are "non-const, const", which looks like "actual, expected"
+warning: arguments are "non-const, const-like", which looks like "actual, expected"
   --> $DIR/main.rs:20:16
    |
 LL |     assert_eq!(x, 0, "this is a message (with parens)");
    |                ^^^^ help: prefer "expected, actual": `0, x`
 
-warning: 3 warnings emitted
+warning: arguments are "non-const, const-like", which looks like "actual, expected"
+  --> $DIR/main.rs:32:16
+   |
+LL |     assert_eq!(x, vec![0, 1, 2]);
+   |                ^^^^^^^^^^^^^^^^ help: prefer "expected, actual": `vec![0, 1, 2], x`
+
+warning: arguments are "non-const, const-like", which looks like "actual, expected"
+  --> $DIR/main.rs:36:16
+   |
+LL |     assert_eq!(x, vec![0; 3]);
+   |                ^^^^^^^^^^^^^ help: prefer "expected, actual": `vec![0; 3], x`
+
+warning: arguments are "non-const, const-like", which looks like "actual, expected"
+  --> $DIR/main.rs:46:9
+   |
+LL | /         vec_with_a_really_long_name,
+LL | |         vec![CONST_WITH_A_REALLY_LONG_NAME, CONST_WITH_A_REALLY_LONG_NAME]
+   | |__________________________________________________________________________^
+   |
+help: prefer "expected, actual"
+   |
+LL ~         vec![CONST_WITH_A_REALLY_LONG_NAME, CONST_WITH_A_REALLY_LONG_NAME],
+LL +         vec_with_a_really_long_name
+   |
+
+warning: 6 warnings emitted
 

--- a/examples/restriction/assert_eq_arg_misordering/ui/main.stderr
+++ b/examples/restriction/assert_eq_arg_misordering/ui/main.stderr
@@ -26,19 +26,19 @@ LL |     assert_eq!(x, 0, "this is a message (with parens)");
    |                ^^^^ help: prefer "expected, actual": `0, x`
 
 warning: arguments are "non-const, const-like", which looks like "actual, expected"
-  --> $DIR/main.rs:32:16
+  --> $DIR/main.rs:24:16
    |
 LL |     assert_eq!(x, vec![0, 1, 2]);
    |                ^^^^^^^^^^^^^^^^ help: prefer "expected, actual": `vec![0, 1, 2], x`
 
 warning: arguments are "non-const, const-like", which looks like "actual, expected"
-  --> $DIR/main.rs:36:16
+  --> $DIR/main.rs:28:16
    |
 LL |     assert_eq!(x, vec![0; 3]);
    |                ^^^^^^^^^^^^^ help: prefer "expected, actual": `vec![0; 3], x`
 
 warning: arguments are "non-const, const-like", which looks like "actual, expected"
-  --> $DIR/main.rs:46:9
+  --> $DIR/main.rs:33:9
    |
 LL | /         vec_with_a_really_long_name,
 LL | |         vec![CONST_WITH_A_REALLY_LONG_NAME, CONST_WITH_A_REALLY_LONG_NAME]


### PR DESCRIPTION
Claude-generated code. Needs to be reviewed.