### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file records user-facing changes to packages `cargo_dylint`, `dylint`, `dylint_driver`, `dylint-link`, `dylint_linting`, and `dylint_testing`. If a change to one of those packages is missing, please [open an issue](https://github.com/trailofbits/dylint/issues).
 
+## 6.0.3
+
+- Invalidate rustc's incremental cache when the set of registered lints changes ([4ca081a](https://github.com/trailofbits/dylint/commit/4ca081a67a3dd69a4ddb4c8386fb4e304fdcfd8c))
+- Remove patch versions from template manifest ([fb21b76](https://github.com/trailofbits/dylint/commit/fb21b766dbf71fcf9db57fc822af1200bd911765))
+
 ## 6.0.2
 
 - Fix a bug causing published binaries to include invalid source paths ([#2011](https://github.com/trailofbits/dylint/pull/2011)). Reported in [#1985](https://github.com/trailofbits/dylint/pull/1985) by [@clabby](https://github.com/clabby), to whom we are sincerely grateful for the initial binary publishing implementation ([#1971](https://github.com/trailofbits/dylint/pull/1971)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dylint"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -544,7 +544,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dylint"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "dylint-link"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_examples"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "cargo-util",
  "cargo_metadata",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_internal"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_testing"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "expensive"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anyhow",
  "dylint_internal",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "nightly"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "nested_workspace",
 ]
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "scheduled"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -288,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -432,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9bb72bb94fdc1bd619f4c18cc91ecf6302aeb333d31b3c6ec0bb841cd920209"
+checksum = "2d83cb7e7a873830708d6b02a78cd36a592c6fa14bf267b68725103b85c0d77f"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
@@ -892,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -1133,15 +1133,15 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc98458dfe90986c5e2f6ddcf68360c7e5c4252600153e06aa4ee8176c0f8d1"
+checksum = "5ee1a0d6e252afe82e7bc2db42fba60e02ddf3b1accaf8cb21d96e34ba61f3d4"
 
 [[package]]
 name = "linktime-proc-macro"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
+checksum = "348d0075b1fc163b26d72a7f75fc5141daf2fd1bdf128d873cbaf6785d495bdf"
 
 [[package]]
 name = "linux-raw-sys"

--- a/cargo-dylint/Cargo.toml
+++ b/cargo-dylint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-dylint"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A tool for running Rust lints from dynamic libraries"
 edition = "2024"
@@ -16,10 +16,10 @@ anyhow = { workspace = true, features = ["backtrace"] }
 clap = { workspace = true, features = ["cargo", "derive", "wrap_help"] }
 env_logger = { workspace = true }
 
-dylint = { version = "=6.0.2", path = "../dylint", features = [
+dylint = { version = "=6.0.3", path = "../dylint", features = [
     "package_options",
 ] }
-dylint_internal = { version = "=6.0.2", path = "../internal" }
+dylint_internal = { version = "=6.0.3", path = "../internal" }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }
@@ -37,7 +37,7 @@ tempfile = { workspace = true }
 toml_edit = { workspace = true }
 walkdir = { workspace = true }
 
-dylint_internal = { version = "=6.0.2", path = "../internal", features = [
+dylint_internal = { version = "=6.0.3", path = "../internal", features = [
     "examples",
     "testing",
 ] }

--- a/driver/Cargo.lock
+++ b/driver/Cargo.lock
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_driver"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anyhow",
  "curl",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_internal"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylint_driver"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "Dylint driver library"
 edition = "2024"
@@ -17,7 +17,7 @@ log = "0.4"
 rustversion = "1.0"
 serde_json = "1.0"
 
-dylint_internal = { version = "=6.0.2", path = "../internal", features = [
+dylint_internal = { version = "=6.0.3", path = "../internal", features = [
     "rustup",
 ] }
 
@@ -29,7 +29,7 @@ proc-macro2 = "1.0"
 rustversion = "1.0"
 syn = { version = "3.0", features = ["full"] }
 
-dylint_internal = { version = "=6.0.2", path = "../internal", features = [
+dylint_internal = { version = "=6.0.3", path = "../internal", features = [
     "clippy_utils",
     "rustup",
 ] }

--- a/dylint-link/Cargo.toml
+++ b/dylint-link/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylint-link"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A wrapper around Rust's default linker to help create Dylint libraries"
 edition = "2024"
@@ -12,20 +12,20 @@ anyhow = { workspace = true }
 env_logger = { workspace = true }
 toml = { workspace = true }
 
-dylint_internal = { version = "=6.0.2", path = "../internal", features = [
+dylint_internal = { version = "=6.0.3", path = "../internal", features = [
     "cargo",
     "rustup",
 ] }
 
 [build-dependencies]
-dylint_internal = { version = "=6.0.2", path = "../internal" }
+dylint_internal = { version = "=6.0.3", path = "../internal" }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
 tempfile = { workspace = true }
 
-dylint_internal = { version = "=6.0.2", path = "../internal", features = [
+dylint_internal = { version = "=6.0.3", path = "../internal", features = [
     "packaging",
 ] }
 

--- a/dylint/Cargo.toml
+++ b/dylint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylint"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A tool for running Rust lints from dynamic libraries"
 edition = "2024"
@@ -40,7 +40,7 @@ toml = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 walkdir = { workspace = true, optional = true }
 
-dylint_internal = { version = "=6.0.2", path = "../internal", features = [
+dylint_internal = { version = "=6.0.3", path = "../internal", features = [
     "config",
     "git",
     "packaging",
@@ -48,14 +48,14 @@ dylint_internal = { version = "=6.0.2", path = "../internal", features = [
 ] }
 
 [build-dependencies]
-dylint_internal = { version = "=6.0.2", path = "../internal", features = [
+dylint_internal = { version = "=6.0.3", path = "../internal", features = [
     "cargo",
 ] }
 
 [dev-dependencies]
 env_logger = { workspace = true }
 
-dylint_internal = { version = "=6.0.2", path = "../internal", features = [
+dylint_internal = { version = "=6.0.3", path = "../internal", features = [
     "examples",
 ] }
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylint_examples"
-version = "6.0.2"
+version = "6.0.3"
 description = "A dummy package for testing the example Dylint libraries"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -18,7 +18,7 @@ toml = { workspace = true }
 toml_edit = { workspace = true }
 walkdir = { workspace = true }
 
-dylint_internal = { version = "=6.0.2", path = "../internal", features = [
+dylint_internal = { version = "=6.0.3", path = "../internal", features = [
     "clippy_utils",
     "examples",
 ] }

--- a/examples/experimental/derive_opportunity/Cargo.lock
+++ b/examples/experimental/derive_opportunity/Cargo.lock
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "derive_opportunity"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "bitflags 2.13.1",
  "clippy_utils",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "dylint"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_internal"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_linting"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "cargo_metadata",
  "dylint_internal",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_testing"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/examples/experimental/derive_opportunity/Cargo.toml
+++ b/examples/experimental/derive_opportunity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive_opportunity"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for traits that could be derived"
 edition = "2024"

--- a/examples/experimental/missing_doc_comment_llm/Cargo.lock
+++ b/examples/experimental/missing_doc_comment_llm/Cargo.lock
@@ -1179,7 +1179,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dylint"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_internal"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -1213,7 +1213,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_linting"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "cargo_metadata",
  "dylint_internal",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_testing"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "missing_doc_comment_llm"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_linting",

--- a/examples/experimental/missing_doc_comment_llm/Cargo.lock
+++ b/examples/experimental/missing_doc_comment_llm/Cargo.lock
@@ -710,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -720,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1702,9 +1702,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -3122,9 +3122,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "once_cell",
  "ring",
@@ -3614,7 +3614,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "serde",
  "serde_json",
  "sha2",
@@ -4011,9 +4011,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -4083,13 +4083,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4108,7 +4108,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "tokio",
 ]
 

--- a/examples/experimental/missing_doc_comment_llm/Cargo.toml
+++ b/examples/experimental/missing_doc_comment_llm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "missing_doc_comment_llm"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint that suggests doc comments using an LLM"
 edition = "2024"

--- a/examples/general/Cargo.lock
+++ b/examples/general/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "abs_home_path"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_internal",
@@ -107,7 +107,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "await_holding_span_guard"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_internal",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "basic_dead_store"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_linting",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "crate_wide_allow"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "assert_cmd",
  "clippy_utils",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "dylint"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_internal"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_linting"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "cargo_metadata",
  "dylint_internal",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_testing"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "general"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "abs_home_path",
  "await_holding_span_guard",
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "incorrect_matches_operation"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_linting",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "non_local_effect_before_unhandled_error"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "bitflags 2.13.1",
  "clippy_utils",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "non_thread_safe_call_in_test"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_internal",
@@ -1381,7 +1381,7 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wrong_serialize_struct_arg"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_internal",

--- a/examples/general/Cargo.lock
+++ b/examples/general/Cargo.lock
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9bb72bb94fdc1bd619f4c18cc91ecf6302aeb333d31b3c6ec0bb841cd920209"
+checksum = "2d83cb7e7a873830708d6b02a78cd36a592c6fa14bf267b68725103b85c0d77f"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
@@ -688,15 +688,15 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc98458dfe90986c5e2f6ddcf68360c7e5c4252600153e06aa4ee8176c0f8d1"
+checksum = "5ee1a0d6e252afe82e7bc2db42fba60e02ddf3b1accaf8cb21d96e34ba61f3d4"
 
 [[package]]
 name = "linktime-proc-macro"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
+checksum = "348d0075b1fc163b26d72a7f75fc5141daf2fd1bdf128d873cbaf6785d495bdf"
 
 [[package]]
 name = "linux-raw-sys"

--- a/examples/general/Cargo.toml
+++ b/examples/general/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "general"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "General-purpose lints"
 edition = "2024"

--- a/examples/general/abs_home_path/Cargo.toml
+++ b/examples/general/abs_home_path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abs_home_path"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for string literals that are absolute paths into the user's home directory"
 edition = "2024"

--- a/examples/general/abs_home_path/ui_build_script/Cargo.lock
+++ b/examples/general/abs_home_path/ui_build_script/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "ui_build_script"
-version = "6.0.2"
+version = "6.0.3"

--- a/examples/general/abs_home_path/ui_build_script/Cargo.toml
+++ b/examples/general/abs_home_path/ui_build_script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ui_build_script"
-version = "6.0.2"
+version = "6.0.3"
 edition = "2024"
 
 [workspace] 

--- a/examples/general/abs_home_path/ui_test/Cargo.lock
+++ b/examples/general/abs_home_path/ui_test/Cargo.lock
@@ -142,7 +142,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "ui_test"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "assert_cmd",
 ]

--- a/examples/general/abs_home_path/ui_test/Cargo.toml
+++ b/examples/general/abs_home_path/ui_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ui_test"
-version = "6.0.2"
+version = "6.0.3"
 edition = "2024"
 
 [dev-dependencies]

--- a/examples/general/await_holding_span_guard/Cargo.toml
+++ b/examples/general/await_holding_span_guard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "await_holding_span_guard"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["David Barsky"]
 description = "A lint to check for Span guards held while calling await inside an async function"
 edition = "2024"

--- a/examples/general/basic_dead_store/Cargo.toml
+++ b/examples/general/basic_dead_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basic_dead_store"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Filipe Casal <fcasal@users.noreply.github.com>"]
 description = "A lint to find simple instances of dead stores in arrays"
 edition = "2024"

--- a/examples/general/crate_wide_allow/Cargo.toml
+++ b/examples/general/crate_wide_allow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crate_wide_allow"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for `#![allow(...)]` used at the crate level"
 edition = "2024"

--- a/examples/general/crate_wide_allow/ui_manifest/Cargo.lock
+++ b/examples/general/crate_wide_allow/ui_manifest/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "ui_manifest"
-version = "6.0.2"
+version = "6.0.3"

--- a/examples/general/crate_wide_allow/ui_manifest/Cargo.toml
+++ b/examples/general/crate_wide_allow/ui_manifest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ui_manifest"
-version = "6.0.2"
+version = "6.0.3"
 edition = "2024"
 
 [lints.clippy]

--- a/examples/general/incorrect_matches_operation/Cargo.toml
+++ b/examples/general/incorrect_matches_operation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incorrect_matches_operation"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Dominik Czarnota <dominik.b.czarnota+dylint@gmail.com>"]
 description = "A lint to check for incorrect operators used with matches! macros"
 edition = "2024"

--- a/examples/general/non_local_effect_before_unhandled_error/Cargo.toml
+++ b/examples/general/non_local_effect_before_unhandled_error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "non_local_effect_before_unhandled_error"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for unhandled errors from functions with non-local effects before error return"
 edition = "2024"

--- a/examples/general/non_thread_safe_call_in_test/Cargo.toml
+++ b/examples/general/non_thread_safe_call_in_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "non_thread_safe_call_in_test"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for non-thread-safe function calls in tests"
 edition = "2024"

--- a/examples/general/wrong_serialize_struct_arg/Cargo.toml
+++ b/examples/general/wrong_serialize_struct_arg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrong_serialize_struct_arg"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for calls to serialization methods with incorrect `len` arguments"
 edition = "2024"

--- a/examples/restriction/Cargo.lock
+++ b/examples/restriction/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "assert_eq_arg_misordering"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_linting",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "collapsible_unwrap"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_linting",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "const_path_join"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "camino",
  "clippy_utils",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "dylint"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_internal"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_linting"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "cargo_metadata",
  "dylint_internal",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_testing"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "env_literal"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_internal",
@@ -575,7 +575,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "inconsistent_qualification"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "diesel",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "misleading_variable_name"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "non_topologically_sorted_functions"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_internal",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "question_mark_in_expression"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_linting",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "ref_aware_redundant_closure_for_method_calls"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_internal",
@@ -896,7 +896,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "register_lints_warn"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_internal",
@@ -1027,7 +1027,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "suboptimal_pattern"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_linting",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "try_io_result"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anyhow",
  "clippy_utils",

--- a/examples/restriction/assert_eq_arg_misordering/Cargo.toml
+++ b/examples/restriction/assert_eq_arg_misordering/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assert_eq_arg_misordering"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for `assert_eq!(actual, expected)`"
 edition = "2024"

--- a/examples/restriction/collapsible_unwrap/Cargo.toml
+++ b/examples/restriction/collapsible_unwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "collapsible_unwrap"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for an `unwrap` that could be combined with an `expect` or `unwrap` using `and_then`"
 edition = "2024"

--- a/examples/restriction/const_path_join/Cargo.toml
+++ b/examples/restriction/const_path_join/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const_path_join"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for joining of constant path components"
 edition = "2024"

--- a/examples/restriction/env_literal/Cargo.toml
+++ b/examples/restriction/env_literal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "env_literal"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for environment variables referred to with string literals"
 edition = "2024"

--- a/examples/restriction/inconsistent_qualification/Cargo.toml
+++ b/examples/restriction/inconsistent_qualification/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inconsistent_qualification"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for inconsistent qualification of module items"
 edition = "2024"

--- a/examples/restriction/misleading_variable_name/Cargo.toml
+++ b/examples/restriction/misleading_variable_name/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "misleading_variable_name"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for variables whose names suggest they have types other than the ones they have"
 edition = "2024"

--- a/examples/restriction/non_topologically_sorted_functions/Cargo.toml
+++ b/examples/restriction/non_topologically_sorted_functions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "non_topologically_sorted_functions"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["J4CK VVH173 <i78901234567890@gmail.com>"]
 description = "A lint to check the function order"
 edition = "2024"

--- a/examples/restriction/question_mark_in_expression/Cargo.toml
+++ b/examples/restriction/question_mark_in_expression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "question_mark_in_expression"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for the `?` operator in expressions"
 edition = "2024"

--- a/examples/restriction/ref_aware_redundant_closure_for_method_calls/Cargo.toml
+++ b/examples/restriction/ref_aware_redundant_closure_for_method_calls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ref_aware_redundant_closure_for_method_calls"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A ref-aware fork of `redundant_closure_for_method_calls`"
 edition = "2024"

--- a/examples/restriction/register_lints_warn/Cargo.toml
+++ b/examples/restriction/register_lints_warn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "register_lints_warn"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for calls to `rustc_errors::DiagCtxtHandle::warn` from within a `register_lints` function"
 edition = "2024"

--- a/examples/restriction/suboptimal_pattern/Cargo.toml
+++ b/examples/restriction/suboptimal_pattern/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "suboptimal_pattern"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for patterns that could perform additional destructuring"
 edition = "2024"

--- a/examples/restriction/try_io_result/Cargo.toml
+++ b/examples/restriction/try_io_result/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "try_io_result"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for the `?` operator applied to `std::io::Result`"
 edition = "2024"

--- a/examples/supplementary/Cargo.lock
+++ b/examples/supplementary/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arg_iter"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_linting",
@@ -207,7 +207,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "commented_out_code"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_linting",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "concatenable_format_args"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_linting",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "dir_entry_path_file_name"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_internal",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "dylint"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_internal"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_linting"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "cargo_metadata",
  "dylint_internal",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_testing"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "escaping_doc_link"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "cargo-util",
  "cargo_metadata",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "inconsistent_struct_pattern"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_linting",
@@ -782,7 +782,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "local_ref_cell"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_internal",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "nonexistent_path_in_comment"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "cargo_metadata",
  "clippy_utils",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "redundant_reference"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_linting",
@@ -1113,7 +1113,7 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "supplementary"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "arg_iter",
  "commented_out_code",
@@ -1324,7 +1324,7 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unnamed_constant"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_linting",
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "unnecessary_borrow_mut"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_internal",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "unnecessary_conversion_for_trait"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_internal",

--- a/examples/supplementary/Cargo.lock
+++ b/examples/supplementary/Cargo.lock
@@ -620,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]

--- a/examples/supplementary/Cargo.toml
+++ b/examples/supplementary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "supplementary"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "Supplementary lints"
 edition = "2024"

--- a/examples/supplementary/arg_iter/Cargo.toml
+++ b/examples/supplementary/arg_iter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arg_iter"
-version = "6.0.2"
+version = "6.0.3"
 edition = "2024"
 publish = false
 

--- a/examples/supplementary/commented_out_code/Cargo.toml
+++ b/examples/supplementary/commented_out_code/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commented_out_code"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for code that has been commented out"
 edition = "2024"

--- a/examples/supplementary/concatenable_format_args/Cargo.toml
+++ b/examples/supplementary/concatenable_format_args/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concatenable_format_args"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Ginza Hatemi <ginzahatemi@gmail.com>"]
 description = "A lint to check for `format!(...)` invocations where `concat!(...)` could be used instead"
 edition = "2024"

--- a/examples/supplementary/dir_entry_path_file_name/Cargo.toml
+++ b/examples/supplementary/dir_entry_path_file_name/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dir_entry_path_file_name"
-version = "6.0.2"
+version = "6.0.3"
 edition = "2024"
 publish = false
 

--- a/examples/supplementary/escaping_doc_link/Cargo.toml
+++ b/examples/supplementary/escaping_doc_link/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "escaping_doc_link"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for doc comment links that escape their packages"
 edition = "2024"

--- a/examples/supplementary/inconsistent_struct_pattern/Cargo.toml
+++ b/examples/supplementary/inconsistent_struct_pattern/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inconsistent_struct_pattern"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for struct patterns whose fields do not match their declared order"
 edition = "2024"

--- a/examples/supplementary/local_ref_cell/Cargo.toml
+++ b/examples/supplementary/local_ref_cell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local_ref_cell"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for `RefCell` local variables"
 edition = "2024"

--- a/examples/supplementary/nonexistent_path_in_comment/Cargo.toml
+++ b/examples/supplementary/nonexistent_path_in_comment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nonexistent_path_in_comment"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Augustin Villetard"]
 description = "Lint for nonexistent paths in comments"
 edition = "2024"

--- a/examples/supplementary/redundant_reference/Cargo.toml
+++ b/examples/supplementary/redundant_reference/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redundant_reference"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for reference fields used only to read one copyable subfield"
 edition = "2024"

--- a/examples/supplementary/unnamed_constant/Cargo.toml
+++ b/examples/supplementary/unnamed_constant/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unnamed_constant"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for unnamed constants, aka magic numbers"
 edition = "2024"

--- a/examples/supplementary/unnecessary_borrow_mut/Cargo.toml
+++ b/examples/supplementary/unnecessary_borrow_mut/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unnecessary_borrow_mut"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for calls to `RefCell::borrow_mut` that could be `RefCell::borrow`"
 edition = "2024"

--- a/examples/supplementary/unnecessary_conversion_for_trait/Cargo.toml
+++ b/examples/supplementary/unnecessary_conversion_for_trait/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unnecessary_conversion_for_trait"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint to check for unnecessary trait-behavior-preserving calls"
 edition = "2024"

--- a/examples/testing/clippy/Cargo.lock
+++ b/examples/testing/clippy/Cargo.lock
@@ -138,7 +138,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clippy"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "dylint"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_internal"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_linting"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "cargo_metadata",
  "dylint_internal",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_testing"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/examples/testing/clippy/Cargo.toml
+++ b/examples/testing/clippy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "All of the Clippy lints as a Dylint library"
 edition = "2024"

--- a/examples/testing/straggler/Cargo.lock
+++ b/examples/testing/straggler/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "dylint"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_internal"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_linting"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "cargo_metadata",
  "dylint_internal",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_testing"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -812,7 +812,7 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "straggler"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clippy_utils",
  "dylint_linting",

--- a/examples/testing/straggler/Cargo.toml
+++ b/examples/testing/straggler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "straggler"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "A lint that uses an old toolchain for testing purposes"
 edition = "2024"

--- a/expensive/Cargo.toml
+++ b/expensive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "expensive"
 description = "Expensive tests"
-version = "6.0.2"
+version = "6.0.3"
 edition = "2024"
 publish = false
 
@@ -12,7 +12,7 @@ semver = { workspace = true }
 snapbox = { workspace = true }
 tempfile = { workspace = true }
 
-dylint_internal = { version = "=6.0.2", path = "../internal", features = [
+dylint_internal = { version = "=6.0.3", path = "../internal", features = [
     "clippy_utils",
     "rustup",
     "testing",

--- a/internal/Cargo.toml
+++ b/internal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylint_internal"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "Dylint internals"
 edition = "2024"

--- a/nightly/Cargo.toml
+++ b/nightly/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nightly"
 description = "Containing package for Dylint workspaces requiring a nightly toolchain"
-version = "6.0.2"
+version = "6.0.3"
 edition = "2024"
 publish = false
 

--- a/scheduled/Cargo.toml
+++ b/scheduled/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scheduled"
 description = "Scheduled tests"
-version = "6.0.2"
+version = "6.0.3"
 edition = "2024"
 publish = false
 
@@ -15,7 +15,7 @@ regex = { workspace = true }
 serde_json = { workspace = true }
 similar-asserts = { workspace = true }
 
-dylint_internal = { version = "=6.0.2", path = "../internal" }
+dylint_internal = { version = "=6.0.3", path = "../internal" }
 
 [lints]
 workspace = true

--- a/utils/linting/Cargo.lock
+++ b/utils/linting/Cargo.lock
@@ -102,7 +102,7 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "dylint_internal"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "dylint_linting"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/utils/linting/Cargo.toml
+++ b/utils/linting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylint_linting"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "Utilities for writing Dylint libraries"
 edition = "2024"
@@ -15,7 +15,7 @@ serde = "1.0"
 thiserror = "2.0"
 toml = "1.1"
 
-dylint_internal = { version = "=6.0.2", path = "../../internal", features = [
+dylint_internal = { version = "=6.0.3", path = "../../internal", features = [
     "config",
 ] }
 

--- a/utils/testing/Cargo.toml
+++ b/utils/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylint_testing"
-version = "6.0.2"
+version = "6.0.3"
 authors = ["Samuel E. Moelius III <sam@moeli.us>"]
 description = "Utilities for testing Dylint libraries"
 edition = "2024"
@@ -17,8 +17,8 @@ regex = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 
-dylint = { version = "=6.0.2", path = "../../dylint" }
-dylint_internal = { version = "=6.0.2", path = "../../internal" }
+dylint = { version = "=6.0.3", path = "../../dylint" }
+dylint_internal = { version = "=6.0.3", path = "../../internal" }
 
 [features]
 default = []


### PR DESCRIPTION
Waiting on Remove patch versions from template manifest (https://github.com/trailofbits/dylint/pull/2022).

However, that PR is a bandaid, as a minor version bump would cause breakage. A long-term fix is needed.