### PR TITLE
Fix `set_toolchain_channel`

### DIFF
--- a/examples/experimental/derive_opportunity/Cargo.lock
+++ b/examples/experimental/derive_opportunity/Cargo.lock
@@ -275,10 +275,13 @@ dependencies = [
  "home",
  "log",
  "regex",
+ "semver",
  "serde",
  "tar",
+ "tempfile",
  "thiserror 2.0.19",
  "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -959,6 +962,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,6 +1153,9 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "xattr"

--- a/examples/experimental/missing_doc_comment_llm/Cargo.lock
+++ b/examples/experimental/missing_doc_comment_llm/Cargo.lock
@@ -490,10 +490,13 @@ dependencies = [
  "home",
  "log",
  "regex",
+ "semver",
  "serde",
  "tar",
+ "tempfile",
  "thiserror 2.0.19",
  "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2299,6 +2302,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2777,6 +2793,9 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/examples/general/Cargo.lock
+++ b/examples/general/Cargo.lock
@@ -365,10 +365,13 @@ dependencies = [
  "home",
  "log",
  "regex",
+ "semver",
  "serde",
  "tar",
+ "tempfile",
  "thiserror 2.0.19",
  "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1179,6 +1182,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1378,6 +1394,9 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wrong_serialize_struct_arg"

--- a/examples/restriction/Cargo.lock
+++ b/examples/restriction/Cargo.lock
@@ -379,10 +379,13 @@ dependencies = [
  "home",
  "log",
  "regex",
+ "semver",
  "serde",
  "tar",
+ "tempfile",
  "thiserror 2.0.19",
  "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1170,6 +1173,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1376,9 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "xattr"

--- a/examples/supplementary/Cargo.lock
+++ b/examples/supplementary/Cargo.lock
@@ -420,10 +420,13 @@ dependencies = [
  "home",
  "log",
  "regex",
+ "semver",
  "serde",
  "tar",
+ "tempfile",
  "thiserror 2.0.19",
  "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1265,6 +1268,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,6 +1521,9 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "xattr"

--- a/examples/testing/clippy/Cargo.lock
+++ b/examples/testing/clippy/Cargo.lock
@@ -329,10 +329,13 @@ dependencies = [
  "home",
  "log",
  "regex",
+ "semver",
  "serde",
  "tar",
+ "tempfile",
  "thiserror 2.0.19",
  "toml 1.1.4+spec-1.1.0",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -1187,7 +1190,7 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -1258,6 +1261,19 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -1487,6 +1503,9 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "writeable"

--- a/examples/testing/straggler/Cargo.lock
+++ b/examples/testing/straggler/Cargo.lock
@@ -261,10 +261,13 @@ dependencies = [
  "home",
  "log",
  "regex",
+ "semver",
  "serde",
  "tar",
+ "tempfile",
  "thiserror 2.0.19",
  "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -954,6 +957,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,6 +1148,9 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "xattr"

--- a/internal/src/clippy_utils/mod.rs
+++ b/internal/src/clippy_utils/mod.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use semver::Version;
 use std::{
     fs::{read_to_string, write},
-    path::Path,
+    path::{Path, PathBuf},
 };
 use toml_edit::{DocumentMut, Item, Value};
 
@@ -73,21 +73,8 @@ pub fn set_clippy_utils_dependency_revision(path: &Path, rev: &str) -> Result<()
 
 /// Extracts the `toolchain.channel` setting from a `rust-toolchain` or `rust-toolchain.toml` file
 pub fn toolchain_channel(path: &Path) -> Result<String> {
-    let rust_toolchain = path.join("rust-toolchain");
-    let rust_toolchain_toml = path.join("rust-toolchain.toml");
-    let contents = match read_to_string(&rust_toolchain) {
-        Ok(contents) => contents,
-        Err(error) => match read_to_string(&rust_toolchain_toml) {
-            Ok(contents) => contents,
-            Err(error_toml) => {
-                bail!(
-                    "`read_to_string` failed for both `{}` and `{}`: {:#?}",
-                    rust_toolchain.to_string_lossy(),
-                    rust_toolchain_toml.to_string_lossy(),
-                    [error, error_toml]
-                );
-            }
-        },
+    let Some((_, contents)) = read_rust_toolchain_file(path)? else {
+        bail!("Could not find rust-toolchain file at `{}`", path.display());
     };
     let table = toml::from_str::<toml::Table>(&contents)?;
     table
@@ -101,13 +88,9 @@ pub fn toolchain_channel(path: &Path) -> Result<String> {
 
 /// Sets `toolchain.channel` in a `rust-toolchain` or `rust-toolchain.toml` file
 pub fn set_toolchain_channel(path: &Path, channel: &str) -> Result<()> {
-    let rust_toolchain = path.join("rust-toolchain");
-    let contents = read_to_string(&rust_toolchain).with_context(|| {
-        format!(
-            "`read_to_string` failed for `{}`",
-            rust_toolchain.to_string_lossy(),
-        )
-    })?;
+    let Some((path_used, contents)) = read_rust_toolchain_file(path)? else {
+        bail!("Could not find rust-toolchain file at `{}`", path.display());
+    };
     let mut document = contents.parse::<DocumentMut>()?;
     document
         .as_table_mut()
@@ -117,5 +100,93 @@ pub fn set_toolchain_channel(path: &Path, channel: &str) -> Result<()> {
         .and_then(Item::as_value_mut)
         .map(|value| *value = Value::from(channel))
         .ok_or_else(|| anyhow!("Could not set Rust toolchain channel"))?;
-    write(rust_toolchain, document.to_string()).map_err(Into::into)
+    write(path_used, document.to_string()).map_err(Into::into)
+}
+
+pub fn read_rust_toolchain_file(path: &Path) -> Result<Option<(PathBuf, String)>> {
+    // smoelius: Rustup gives precedence to `rust-toolchain` over `rust-toolchain.toml`:
+    // https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
+    let rust_toolchain_path = path.join("rust-toolchain");
+    let rust_toolchain_toml_path = path.join("rust-toolchain.toml");
+    if rust_toolchain_path.try_exists().with_context(|| {
+        format!(
+            "Could not determine whether `{}` exists",
+            rust_toolchain_path.display(),
+        )
+    })? {
+        let contents = read_to_string(&rust_toolchain_path).with_context(|| {
+            format!(
+                "`read_to_string` failed for `{}`",
+                rust_toolchain_path.display(),
+            )
+        })?;
+        return Ok(Some((rust_toolchain_path, contents)));
+    }
+    if rust_toolchain_toml_path.try_exists().with_context(|| {
+        format!(
+            "Could not determine whether `{}` exists",
+            rust_toolchain_toml_path.display(),
+        )
+    })? {
+        let contents = read_to_string(&rust_toolchain_toml_path).with_context(|| {
+            format!(
+                "`read_to_string` failed for `{}`",
+                rust_toolchain_toml_path.display(),
+            )
+        })?;
+        return Ok(Some((rust_toolchain_toml_path, contents)));
+    }
+    Ok(None)
+}
+
+#[allow(clippy::unwrap_used)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::read_dir;
+    use tempfile::tempdir;
+
+    const BEFORE: &str = r#"[toolchain]
+channel = "nightly-2025-01-02"
+components = ["llvm-tools-preview", "rustc-dev"]
+"#;
+
+    const AFTER: &str = r#"[toolchain]
+channel = "nightly-2025-03-04"
+components = ["llvm-tools-preview", "rustc-dev"]
+"#;
+
+    #[cfg_attr(dylint_lib = "general", allow(non_thread_safe_call_in_test))]
+    #[test]
+    fn set_toolchain_channel_rust_toolchain() {
+        check_set_toolchain_channel("rust-toolchain");
+    }
+
+    #[cfg_attr(dylint_lib = "general", allow(non_thread_safe_call_in_test))]
+    #[test]
+    fn set_toolchain_channel_rust_toolchain_toml() {
+        check_set_toolchain_channel("rust-toolchain.toml");
+    }
+
+    fn check_set_toolchain_channel(filename: &str) {
+        let tempdir = tempdir().unwrap();
+        write(tempdir.path().join(filename), BEFORE).unwrap();
+
+        set_toolchain_channel(tempdir.path(), "nightly-2025-03-04").unwrap();
+
+        assert_eq!(
+            "nightly-2025-03-04",
+            toolchain_channel(tempdir.path()).unwrap()
+        );
+
+        // The channel should be the only thing that changed.
+        assert_eq!(
+            AFTER,
+            read_to_string(tempdir.path().join(filename)).unwrap()
+        );
+
+        // The file that was present should have been written; the other should not have been
+        // created.
+        assert_eq!(1, read_dir(&tempdir).unwrap().count());
+    }
 }

--- a/utils/linting/Cargo.lock
+++ b/utils/linting/Cargo.lock
@@ -89,6 +89,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,11 +118,15 @@ version = "6.0.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
+ "git2",
  "log",
  "regex",
+ "semver",
  "serde",
+ "tempfile",
  "thiserror",
  "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -152,6 +168,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +182,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+]
+
+[[package]]
+name = "git2"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
 ]
 
 [[package]]
@@ -185,10 +219,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom",
+ "libc",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.18.7+1.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23c7391e4b9f4ffab1a624223cc1d7385ff9a678f490768add717de7ea2f4d89"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -219,6 +287,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "predicates"
@@ -391,6 +465,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "syn"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +545,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +577,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "wait-timeout"
@@ -514,6 +613,9 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "zmij"

--- a/utils/linting/Cargo.toml
+++ b/utils/linting/Cargo.toml
@@ -22,6 +22,10 @@ dylint_internal = { version = "=6.0.3", path = "../../internal", features = [
 [build-dependencies]
 toml = "1.1"
 
+dylint_internal = { version = "=6.0.3", path = "../../internal", features = [
+    "clippy_utils",
+] }
+
 [dev-dependencies]
 assert_cmd = "2.2"
 rustc_version = "0.4"

--- a/utils/linting/build.rs
+++ b/utils/linting/build.rs
@@ -8,16 +8,17 @@ fn main() {
 }
 
 fn check_components() {
-    use std::{fs::read_to_string, path::Path};
+    use dylint_internal::{clippy_utils, env};
+    use std::{env::var_os, path::PathBuf};
     use toml::{Table, Value};
 
-    let rust_toolchain = Path::new("rust-toolchain");
+    let manifest_dir = var_os(env::CARGO_MANIFEST_DIR).unwrap();
+    let path = PathBuf::from(manifest_dir);
 
-    if !rust_toolchain.try_exists().unwrap() {
+    let Some((_, contents)) = clippy_utils::read_rust_toolchain_file(&path).unwrap() else {
         return;
-    }
+    };
 
-    let contents = read_to_string(rust_toolchain).unwrap();
     let table = contents.parse::<Table>().unwrap();
     let array = table
         .get("toolchain")


### PR DESCRIPTION
This internal function's rustdoc comment claimed that it worked for both rust-toolchain and rust-toolchain.toml files. It didn't.