### PR TITLE
Remove ssh-key from "Upgrade examples" workflow

### DIFF
--- a/.github/workflows/upgrade_examples.yml
+++ b/.github/workflows/upgrade_examples.yml
@@ -17,10 +17,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-        with:
-          # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
-          # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-using-ssh-deploy-keys
-          ssh-key: ${{ secrets.SSH_KEY }}
 
       - name: Rustup
         run: rustup update
@@ -40,4 +36,9 @@ jobs:
           branch: upgrade-examples
           branch-suffix: random
           commit-message: Upgrade examples
+          # smoelius: Using a PAT causes the PR to trigger the `ci.yml` workflow. Note that if the
+          # PAT is classic, it must have `repo` scope; if the PAT is fine-grained, it must have
+          # permissions `contents: write` and `pull-requests: write`. See:
+          # - https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+          # - https://github.com/peter-evans/create-pull-request#token
           token: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
Claude-generated PR description follows.

## Remove `ssh-key` from the "Upgrade examples" workflow

Removes `ssh-key: ${{ secrets.SSH_KEY }}` from the `actions/checkout` step in
`.github/workflows/upgrade_examples.yml`, and adds a comment above `token` recording why
a PAT is used and what it must be granted.

### Why

The workflow configured two credentials that address the same problem: pull requests
created with the default `GITHUB_TOKEN` do not trigger further workflow runs. The
action's docs list SSH deploy keys and a PAT as alternatives, and are explicit about
what each provides:

> Use [SSH (deploy keys)](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-using-ssh-deploy-keys)
> to push the pull request branch. […] However, this method will only trigger
> `on: push` workflows.

> Use a Personal Access Token (PAT) […] This is the standard workaround and
> recommended by GitHub.

This repository has no `on: push` workflow for branches. `ci.yml` triggers on
`merge_group`, `pull_request`, `schedule`, and `workflow_dispatch`; `release.yml`
triggers on `push` but is restricted to `tags: v*`, which an `upgrade-examples-<random>`
branch does not match. The deploy key therefore has no effect on which workflows run.

`REPO_TOKEN` is what causes the generated pull request to fire `pull_request` events, so
`ci.yml` runs on it. That matters here, because the point of the pull request is to find
out whether the upgraded examples still build, as noted in `scripts/upgrade_examples.sh`:

```sh
# smoelius: If the upgraded library does not build, let CI fail after the PR has been
# created, not now.
```

### Effect on the push

With `ssh-key` removed, `actions/checkout` leaves an HTTPS remote, and
`create-pull-request` pushes the branch using `branch-token`, which
[defaults to the value of `token`](https://github.com/peter-evans/create-pull-request#action-inputs) — i.e. `REPO_TOKEN`. A classic PAT needs `repo` scope; a fine-grained PAT needs
`contents: write` and `pull-requests: write` permissions.

`scripts/upgrade_examples.sh` uses only local git operations (`git diff`), so it does not
depend on the remote being SSH.